### PR TITLE
Add several checks for properly including or omitting Form CLS

### DIFF
--- a/nacc/uds3/clsform.py
+++ b/nacc/uds3/clsform.py
@@ -1,0 +1,98 @@
+import datetime
+
+
+def add_cls(record, packet, forms):
+    """
+    Adds CLS form to packet.
+
+    According to the IVP Guidebook (v3.0, March 2015), Form CLS should be
+    completed if the subject or co-participant indicates that the subject is
+    Hispanic/Latino.
+
+    Therefore, if the subject is not Hispanic/Latino, do not add a CLS.
+
+    IVP Guidebook:
+      https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/UDS3_ivp_guidebook.pdf
+
+    Form CLS:
+      https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/CLS/CLS_en.pdf
+    """
+
+    is_hispanic = record['hispanic'] == '1'
+    if not is_hispanic:
+        return
+
+    fields_mapping = {
+        'APREFLAN': 'eng_preferred_language',
+        'AYRSPAN': 'eng_years_speak_spanish',
+        'AYRENGL': 'eng_years_speak_english',
+        'APCSPAN': 'eng_percentage_spanish',
+        'APCENGL': 'eng_percentage_english',
+        'ASPKSPAN': 'eng_proficiency_spanish',
+        'AREASPAN': 'eng_proficiency_read_spanish',
+        'AWRISPAN': 'eng_proficiency_write_spanish',
+        'AUNDSPAN': 'eng_proficiency_oral_spanish',
+        'ASPKENGL': 'eng_proficiency_speak_english',
+        'AREAENGL': 'eng_proficiency_read_english',
+        'AWRIENGL': 'eng_proficiency_write_english',
+        'AUNDENGL': 'eng_proficiency_oral_english',
+    }
+
+    num_filled_fields = 0
+    total_fields = len(fields_mapping)
+    cls_form = forms.FormCLS()
+
+    for key, val in fields_mapping.iteritems():
+        if record[val].strip():
+            setattr(cls_form, key, record[val])
+            num_filled_fields += 1
+
+    # If every field is blank, return
+    if num_filled_fields == 0:
+        return
+
+    # If only some of the fields are filled, raise error.
+    ptid = record.get('ptid', 'unknown')
+    if num_filled_fields != total_fields:
+        msg = "Could not parse packet as CLS form is incomplete for PTID: " \
+            + ptid
+        raise Exception(msg)
+
+    # Otherwise, check percentages and dates before appending.
+
+    # Check percentages
+    try:
+        pct_spn = int(record['eng_percentage_spanish'])
+    except ValueError:
+        raise Exception(
+            "Could not parse packet as eng_percentage_spanish is not an "
+            "integer for PTID: " + ptid
+        )
+
+    try:
+        pct_eng = int(record['eng_percentage_english'])
+    except ValueError:
+        raise Exception(
+            "Could not parse packet as eng_percentage_english is not an "
+            "integer for PTID: " + ptid
+        )
+
+    if pct_eng + pct_spn != 100:
+        message = "Could not parse packet as language proficiency " + \
+            "percentages do not equal 100 for PTID : " + ptid
+        raise Exception(message)
+
+    visit_date = datetime.datetime(
+        int(record['visityr']), int(record['visitmo']), 1)
+    cls_added = datetime.datetime(2017, 6, 1)
+    if visit_date < cls_added:
+        message = "Could not parse packet as CLS forms should not be in " + \
+            "packets from before June 1, 2017 for PTID: " + ptid
+        raise Exception(message)
+
+    if record['form_cls_linguistic_history_of_subject_complete'] != '2':
+        message = "Could not parse packet as completed CLS form is not " + \
+            "marked complete in REDCap for PTID: " + ptid
+        raise Exception(message)
+
+    packet.append(cls_form)

--- a/nacc/uds3/fvp/builder.py
+++ b/nacc/uds3/fvp/builder.py
@@ -6,6 +6,7 @@
 
 from nacc.uds3 import blanks
 import forms as fvp_forms
+from nacc.uds3 import clsform
 from nacc.uds3 import packet as fvp_packet
 
 def build_uds3_fvp_form(record):
@@ -566,52 +567,7 @@ def build_uds3_fvp_form(record):
         else:
             addC1S(record, packet)
 
-    cls_form = fvp_forms.FormCLS()
-    cls_form.APREFLAN = record['eng_preferred_language']
-    cls_form.AYRSPAN = record['eng_years_speak_spanish']
-    cls_form.AYRENGL = record['eng_years_speak_english']
-    cls_form.APCSPAN = record['eng_percentage_spanish']
-    cls_form.APCENGL = record['eng_percentage_english']
-    cls_form.ASPKSPAN = record['eng_proficiency_spanish']
-    cls_form.AREASPAN = record['eng_proficiency_read_spanish']
-    cls_form.AWRISPAN = record['eng_proficiency_write_spanish']
-    cls_form.AUNDSPAN = record['eng_proficiency_oral_spanish']
-    cls_form.ASPKENGL = record['eng_proficiency_speak_english']
-    cls_form.AREAENGL = record['eng_proficiency_read_english']
-    cls_form.AWRIENGL = record['eng_proficiency_write_english']
-    cls_form.AUNDENGL = record['eng_proficiency_oral_english']
-    packet.append(cls_form)
-
-    if ['fu_clslang'] == 1: #Yes, CLS filled out
-        if len(record['eng_percentage_spanish'].strip()) == 0:
-            pct_spn = 0
-        else:
-            pct_spn = int(record['eng_percentage_spanish'])
-
-        if len(record['eng_percentage_english'].strip()) == 0:
-            pct_eng = 0
-        else:
-            pct_eng = int(record['eng_percentage_english'])
-
-        post_cls = True
-        if (record['visityr']<'2017') or (record['visityr']=='2017' and int(record['visitmo'])<6):
-            post_cls = False
-
-        bad_pct = False
-        if (pct_eng + pct_spn)!=100:
-            bad_pct = True
-
-        if (post_cls and bad_pct):
-            ptid = record['ptid']
-            message = "Could not parse packet as language proficiency percentages do not equal 100"
-            message = message + " for PTID : " + ("unknown" if not ptid else ptid)
-            raise Exception(message)
-
-        if not post_cls and (pct_spn!=0 or pct_eng!=0):
-            ptid = record['ptid']
-            message = "Could not parse packet as CLS forms should not be in packets from before June 1, 2017"
-            message = message + " for PTID : " + ("unknown" if not ptid else ptid)
-            raise Exception(message)
+    clsform.add_cls(record, packet, fvp_forms)
 
     d1 = fvp_forms.FormD1()
     d1.DXMETHOD  = record['fu_dxmethod']

--- a/nacc/uds3/ivp/builder.py
+++ b/nacc/uds3/ivp/builder.py
@@ -947,6 +947,11 @@ def add_cls(record, packet):
             "packets from before June 1, 2017 for PTID: " + ptid
         raise Exception(message)
 
+    if record['form_cls_linguistic_history_of_subject_complete'] != '2':
+        message = "Could not parse packet as completed CLS form is not " + \
+            "marked complete in REDCap for PTID: " + ptid
+        raise Exception(message)
+
     packet.append(cls_form)
 
 

--- a/nacc/uds3/ivp/builder.py
+++ b/nacc/uds3/ivp/builder.py
@@ -858,8 +858,21 @@ def build_uds3_ivp_form(record):
 
 
 def add_cls(record, packet):
-    """Adds CLS form to packet."""
+    """
+    Adds CLS form to packet.
 
+    According to the IVP Guidebook (v3.0, March 2015), Form CLS should be
+    completed if the subject or co-participant indicates that the subject is
+    Hispanic/Latino.
+
+    Therefore, if the subject is not Hispanic/Latino, do not add a CLS.
+
+    IVP Guidebook:
+      https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/UDS3_ivp_guidebook.pdf
+
+    Form CLS:
+      https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/CLS/CLS_en.pdf
+    """
     cls_form = ivp_forms.FormCLS()
     cls_form.APREFLAN = record['eng_preferred_language']
     cls_form.AYRSPAN = record['eng_years_speak_spanish']

--- a/nacc/uds3/ivp/builder.py
+++ b/nacc/uds3/ivp/builder.py
@@ -656,52 +656,7 @@ def build_uds3_ivp_form(record):
         else:
             addC1S(record, packet)
 
-    cls_form = ivp_forms.FormCLS()
-    cls_form.APREFLAN = record['eng_preferred_language']
-    cls_form.AYRSPAN = record['eng_years_speak_spanish']
-    cls_form.AYRENGL = record['eng_years_speak_english']
-    cls_form.APCSPAN = record['eng_percentage_spanish']
-    cls_form.APCENGL = record['eng_percentage_english']
-    cls_form.ASPKSPAN = record['eng_proficiency_spanish']
-    cls_form.AREASPAN = record['eng_proficiency_read_spanish']
-    cls_form.AWRISPAN = record['eng_proficiency_write_spanish']
-    cls_form.AUNDSPAN = record['eng_proficiency_oral_spanish']
-    cls_form.ASPKENGL = record['eng_proficiency_speak_english']
-    cls_form.AREAENGL = record['eng_proficiency_read_english']
-    cls_form.AWRIENGL = record['eng_proficiency_write_english']
-    cls_form.AUNDENGL = record['eng_proficiency_oral_english']
-    packet.append(cls_form)
-
-    if record['clslang'] == 1: #yes, CLS lang completed
-        if len(record['eng_percentage_spanish'].strip()) == 0:
-            pct_spn = 0
-        else:
-            pct_spn = int(record['eng_percentage_spanish'])
-
-        if len(record['eng_percentage_english'].strip()) == 0:
-            pct_eng = 0
-        else:
-            pct_eng = int(record['eng_percentage_english'])
-
-        post_cls = True
-        if (record['visityr']<'2017') or (record['visityr']=='2017' and int(record['visitmo'])<6):
-            post_cls = False
-
-        bad_pct = False
-        if (pct_eng + pct_spn)!=100:
-            bad_pct = True
-
-        if (post_cls and bad_pct):
-            ptid = record['ptid']
-            message = "Could not parse packet as language proficiency percentages do not equal 100"
-            message = message + " for PTID : " + ("unknown" if not ptid else ptid)
-            raise Exception(message)
-
-        if not post_cls and (pct_spn!=0 or pct_eng!=0):
-            ptid = record['ptid']
-            message = "Could not parse packet as CLS forms should not be in packets from before June 1, 2017"
-            message = message + " for PTID : " + ("unknown" if not ptid else ptid)
-            raise Exception(message)
+    add_cls(record, packet)
         
     d1 = ivp_forms.FormD1()
     d1.DXMETHOD = record['dxmethod']
@@ -900,6 +855,58 @@ def build_uds3_ivp_form(record):
     update_header(record, packet)
 
     return packet
+
+
+def add_cls(record, packet):
+    """Adds CLS form to packet."""
+
+    cls_form = ivp_forms.FormCLS()
+    cls_form.APREFLAN = record['eng_preferred_language']
+    cls_form.AYRSPAN = record['eng_years_speak_spanish']
+    cls_form.AYRENGL = record['eng_years_speak_english']
+    cls_form.APCSPAN = record['eng_percentage_spanish']
+    cls_form.APCENGL = record['eng_percentage_english']
+    cls_form.ASPKSPAN = record['eng_proficiency_spanish']
+    cls_form.AREASPAN = record['eng_proficiency_read_spanish']
+    cls_form.AWRISPAN = record['eng_proficiency_write_spanish']
+    cls_form.AUNDSPAN = record['eng_proficiency_oral_spanish']
+    cls_form.ASPKENGL = record['eng_proficiency_speak_english']
+    cls_form.AREAENGL = record['eng_proficiency_read_english']
+    cls_form.AWRIENGL = record['eng_proficiency_write_english']
+    cls_form.AUNDENGL = record['eng_proficiency_oral_english']
+    packet.append(cls_form)
+
+    if record['clslang'] == 1: #yes, CLS lang completed
+        if len(record['eng_percentage_spanish'].strip()) == 0:
+            pct_spn = 0
+        else:
+            pct_spn = int(record['eng_percentage_spanish'])
+
+        if len(record['eng_percentage_english'].strip()) == 0:
+            pct_eng = 0
+        else:
+            pct_eng = int(record['eng_percentage_english'])
+
+        post_cls = True
+        if (record['visityr']<'2017') or (record['visityr']=='2017' and int(record['visitmo'])<6):
+            post_cls = False
+
+        bad_pct = False
+        if (pct_eng + pct_spn)!=100:
+            bad_pct = True
+
+        if (post_cls and bad_pct):
+            ptid = record['ptid']
+            message = "Could not parse packet as language proficiency percentages do not equal 100"
+            message = message + " for PTID : " + ("unknown" if not ptid else ptid)
+            raise Exception(message)
+
+        if not post_cls and (pct_spn!=0 or pct_eng!=0):
+            ptid = record['ptid']
+            message = "Could not parse packet as CLS forms should not be in packets from before June 1, 2017"
+            message = message + " for PTID : " + ("unknown" if not ptid else ptid)
+            raise Exception(message)
+
 
 def addZ1(record, packet):
     z1 = ivp_forms.FormZ1()

--- a/nacc/uds3/ivp/builder.py
+++ b/nacc/uds3/ivp/builder.py
@@ -5,9 +5,9 @@
 ###############################################################################
 
 from nacc.uds3 import blanks
+from nacc.uds3 import clsform
 import forms as ivp_forms
 from nacc.uds3 import packet as ivp_packet
-import datetime
 import sys
 
 
@@ -658,8 +658,8 @@ def build_uds3_ivp_form(record):
         else:
             addC1S(record, packet)
 
-    add_cls(record, packet)
-        
+    clsform.add_cls(record, packet, ivp_forms)
+
     d1 = ivp_forms.FormD1()
     d1.DXMETHOD = record['dxmethod']
     d1.NORMCOG = record['normcog']
@@ -859,101 +859,6 @@ def build_uds3_ivp_form(record):
     return packet
 
 
-def add_cls(record, packet):
-    """
-    Adds CLS form to packet.
-
-    According to the IVP Guidebook (v3.0, March 2015), Form CLS should be
-    completed if the subject or co-participant indicates that the subject is
-    Hispanic/Latino.
-
-    Therefore, if the subject is not Hispanic/Latino, do not add a CLS.
-
-    IVP Guidebook:
-      https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/UDS3_ivp_guidebook.pdf
-
-    Form CLS:
-      https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/CLS/CLS_en.pdf
-    """
-
-    is_hispanic = record['hispanic'] == '1'
-    if not is_hispanic:
-        return
-
-    fields_mapping = {
-        'APREFLAN': 'eng_preferred_language',
-        'AYRSPAN': 'eng_years_speak_spanish',
-        'AYRENGL': 'eng_years_speak_english',
-        'APCSPAN': 'eng_percentage_spanish',
-        'APCENGL': 'eng_percentage_english',
-        'ASPKSPAN': 'eng_proficiency_spanish',
-        'AREASPAN': 'eng_proficiency_read_spanish',
-        'AWRISPAN': 'eng_proficiency_write_spanish',
-        'AUNDSPAN': 'eng_proficiency_oral_spanish',
-        'ASPKENGL': 'eng_proficiency_speak_english',
-        'AREAENGL': 'eng_proficiency_read_english',
-        'AWRIENGL': 'eng_proficiency_write_english',
-        'AUNDENGL': 'eng_proficiency_oral_english',
-    }
-
-    num_filled_fields = 0
-    total_fields = len(fields_mapping)
-    cls_form = ivp_forms.FormCLS()
-
-    for key, val in fields_mapping.iteritems():
-        if record[val].strip():
-            setattr(cls_form, key, record[val])
-            num_filled_fields += 1
-
-    # If every field is blank, return
-    if num_filled_fields == 0:
-        return
-
-    # If only some of the fields are filled, raise error.
-    ptid = record.get('ptid', 'unknown')
-    if num_filled_fields != total_fields:
-        msg = "Could not parse packet as CLS form is incomplete for PTID: " \
-            + ptid
-        raise Exception(msg)
-
-    # Otherwise, check percentages and dates before appending.
-
-    # Check percentages
-    try:
-        pct_spn = int(record['eng_percentage_spanish'])
-    except ValueError:
-        raise Exception(
-            "Could not parse packet as eng_percentage_spanish is not an "
-            "integer for PTID: " + ptid
-        )
-
-    try:
-        pct_eng = int(record['eng_percentage_english'])
-    except ValueError:
-        raise Exception(
-            "Could not parse packet as eng_percentage_english is not an "
-            "integer for PTID: " + ptid
-        )
-
-    if pct_eng + pct_spn != 100:
-        message = "Could not parse packet as language proficiency " + \
-            "percentages do not equal 100 for PTID : " + ptid
-        raise Exception(message)
-
-    visit_date = datetime.datetime(int(record['visityr']), int(record['visitmo']), 1)
-    cls_added = datetime.datetime(2017, 6, 1)
-    if visit_date < cls_added:
-        message = "Could not parse packet as CLS forms should not be in " + \
-            "packets from before June 1, 2017 for PTID: " + ptid
-        raise Exception(message)
-
-    if record['form_cls_linguistic_history_of_subject_complete'] != '2':
-        message = "Could not parse packet as completed CLS form is not " + \
-            "marked complete in REDCap for PTID: " + ptid
-        raise Exception(message)
-
-    packet.append(cls_form)
-
 
 def addZ1(record, packet):
     z1 = ivp_forms.FormZ1()
@@ -1035,6 +940,7 @@ def addZ1X(record, packet):
     z1x.LANGCLS = record['clslang']
     z1x.CLSSUB  = record['clssubmitted']
     packet.insert(0, z1x)
+
 
 def addC1S(record, packet):
     c1s = ivp_forms.FormC1S()

--- a/tests/cls_test.py
+++ b/tests/cls_test.py
@@ -66,6 +66,15 @@ class TestCLS(unittest.TestCase):
         with self.assertRaises(Exception):
             builder.add_cls(record, packet)
 
+    def test_cls_form_marked_complete(self):
+        """If the completed CLS form is not marked complete, raise."""
+        packet = ivp_packet.Packet()
+        record = make_filled_record()
+        record['form_cls_linguistic_history_of_subject_complete'] = '0 or 1'
+
+        with self.assertRaises(Exception):
+            builder.add_cls(record, packet)
+
 
 def make_blank_record():
     return {
@@ -83,6 +92,9 @@ def make_blank_record():
         'eng_proficiency_write_english': '',
         'eng_proficiency_oral_english': '',
         'hispanic': '',  # This is from Form A1
+        'visityr': '',
+        'visitmo': '',
+        'form_cls_linguistic_history_of_subject_complete': '',
     }
 
 
@@ -104,6 +116,7 @@ def make_filled_record():
         'hispanic': '1',
         'visityr': '2018',
         'visitmo': '11',
+        'form_cls_linguistic_history_of_subject_complete': '2',
     }
 
 

--- a/tests/cls_test.py
+++ b/tests/cls_test.py
@@ -12,7 +12,7 @@ class TestCLS(unittest.TestCase):
         record = make_record()
 
         builder.add_cls(record, packet)
-        self.assertEqual(len(packet), 0)
+        self.assertEqual(len(packet), 0, "Expected packet to be empty")
 
     def test_cls_not_added_if_not_hispanic(self):
         """
@@ -25,7 +25,7 @@ class TestCLS(unittest.TestCase):
         record['hispanic'] = '0'  # Subject is not Hispanic/Latino.
 
         builder.add_cls(record, packet)
-        self.assertEqual(len(packet), 0)
+        self.assertEqual(len(packet), 0, "Expected packet to be empty")
 
 
 def make_record():

--- a/tests/cls_test.py
+++ b/tests/cls_test.py
@@ -1,19 +1,25 @@
 import unittest
 
-from nacc.uds3 import packet as ivp_packet
-from nacc.uds3.ivp import builder
+from nacc.uds3 import clsform
+from nacc.uds3 import packet
+from nacc.uds3.fvp import forms as fvp_forms
+from nacc.uds3.ivp import forms as ivp_forms
 
 
 class TestCLS(unittest.TestCase):
 
     def test_cls_blank_not_added_to_ivp(self):
         """Don't add blank CLS form to IVP."""
-        packet = ivp_packet.Packet()
         record = make_blank_record()
         record['hispanic'] = '1'  # Subject is Hispanic/Latino.
 
-        builder.add_cls(record, packet)
-        self.assertEqual(len(packet), 0, "Expected packet to be empty")
+        ipacket = packet.Packet()
+        clsform.add_cls(record, ipacket, ivp_forms)
+        self.assertEqual(len(ipacket), 0, "Expected packet to be empty")
+
+        fpacket = packet.Packet()
+        clsform.add_cls(record, fpacket, fvp_forms)
+        self.assertEqual(len(fpacket), 0, "Expected packet to be empty")
 
     def test_cls_not_added_if_not_hispanic(self):
         """
@@ -21,59 +27,83 @@ class TestCLS(unittest.TestCase):
 
         https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/CLS/CLS_en.pdf
         """
-        packet = ivp_packet.Packet()
         record = make_blank_record()
         record['hispanic'] = '0'  # Subject is not Hispanic/Latino.
 
-        builder.add_cls(record, packet)
-        self.assertEqual(len(packet), 0, "Expected packet to be empty")
+        ipacket = packet.Packet()
+        clsform.add_cls(record, ipacket, ivp_forms)
+        self.assertEqual(len(ipacket), 0, "Expected packet to be empty")
+
+        fpacket = packet.Packet()
+        clsform.add_cls(record, fpacket, fvp_forms)
+        self.assertEqual(len(fpacket), 0, "Expected packet to be empty")
 
     def test_cls_added_when_filled(self):
-        """Add filled CLS form to IVP."""
-        packet = ivp_packet.Packet()
+        """Add filled CLS form to IVP and FVP."""
         record = make_filled_record()
 
-        builder.add_cls(record, packet)
-        self.assertEqual(len(packet), 1, "Expected packet to have CLS")
+        ipacket = packet.Packet()
+        clsform.add_cls(record, ipacket, ivp_forms)
+        self.assertEqual(len(ipacket), 1, "Expected packet to have CLS")
+
+        fpacket = packet.Packet()
+        clsform.add_cls(record, fpacket, fvp_forms)
+        self.assertEqual(len(fpacket), 1, "Expected packet to have CLS")
 
     def test_partial_cls_raises_error(self):
         """Partially completed CLS should raise an exception."""
-        packet = ivp_packet.Packet()
         record = make_filled_record()
         record['eng_preferred_language'] = ' '  # Make form partially complete.
 
+        ipacket = packet.Packet()
         with self.assertRaises(Exception):
-            builder.add_cls(record, packet)
+            clsform.add_cls(record, ipacket, ivp_forms)
+
+        fpacket = packet.Packet()
+        with self.assertRaises(Exception):
+            clsform.add_cls(record, fpacket, fvp_forms)
 
     def test_cls_proficiency_must_be_100(self):
         """Language proficiency percentages must sum to 100."""
-        packet = ivp_packet.Packet()
         record = make_filled_record()
         record['eng_percentage_english'] = '20'
         record['eng_percentage_spanish'] = '9001'
 
+        ipacket = packet.Packet()
         with self.assertRaises(Exception):
-            builder.add_cls(record, packet)
+            clsform.add_cls(record, ipacket, ivp_forms)
+
+        fpacket = packet.Packet()
+        with self.assertRaises(Exception):
+            clsform.add_cls(record, fpacket, fvp_forms)
 
     def test_check_cls_date(self):
         """
         Having a CLS with a visit date before June 1, 2017 raises an exception.
         """
-        packet = ivp_packet.Packet()
         record = make_filled_record()
         record['visityr'] = '2016'
 
+        ipacket = packet.Packet()
         with self.assertRaises(Exception):
-            builder.add_cls(record, packet)
+            clsform.add_cls(record, ipacket, ivp_forms)
+
+        fpacket = packet.Packet()
+        with self.assertRaises(Exception):
+            clsform.add_cls(record, fpacket, fvp_forms)
 
     def test_cls_form_marked_complete(self):
         """If the completed CLS form is not marked complete, raise."""
-        packet = ivp_packet.Packet()
         record = make_filled_record()
         record['form_cls_linguistic_history_of_subject_complete'] = '0 or 1'
 
+        ipacket = packet.Packet()
         with self.assertRaises(Exception):
-            builder.add_cls(record, packet)
+            clsform.add_cls(record, ipacket, ivp_forms)
+
+        fpacket = packet.Packet()
+        with self.assertRaises(Exception):
+            clsform.add_cls(record, fpacket, fvp_forms)
 
 
 def make_blank_record():

--- a/tests/cls_test.py
+++ b/tests/cls_test.py
@@ -9,7 +9,8 @@ class TestCLS(unittest.TestCase):
     def test_cls_blank_not_added_to_ivp(self):
         """Don't add blank CLS form to IVP."""
         packet = ivp_packet.Packet()
-        record = make_record()
+        record = make_blank_record()
+        record['hispanic'] = '1'  # Subject is Hispanic/Latino.
 
         builder.add_cls(record, packet)
         self.assertEqual(len(packet), 0, "Expected packet to be empty")
@@ -21,14 +22,52 @@ class TestCLS(unittest.TestCase):
         https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/CLS/CLS_en.pdf
         """
         packet = ivp_packet.Packet()
-        record = make_record()
+        record = make_blank_record()
         record['hispanic'] = '0'  # Subject is not Hispanic/Latino.
 
         builder.add_cls(record, packet)
         self.assertEqual(len(packet), 0, "Expected packet to be empty")
 
+    def test_cls_added_when_filled(self):
+        """Add filled CLS form to IVP."""
+        packet = ivp_packet.Packet()
+        record = make_filled_record()
 
-def make_record():
+        builder.add_cls(record, packet)
+        self.assertEqual(len(packet), 1, "Expected packet to have CLS")
+
+    def test_partial_cls_raises_error(self):
+        """Partially completed CLS should raise an exception."""
+        packet = ivp_packet.Packet()
+        record = make_filled_record()
+        record['eng_preferred_language'] = ' '  # Make form partially complete.
+
+        with self.assertRaises(Exception):
+            builder.add_cls(record, packet)
+
+    def test_cls_proficiency_must_be_100(self):
+        """Language proficiency percentages must sum to 100."""
+        packet = ivp_packet.Packet()
+        record = make_filled_record()
+        record['eng_percentage_english'] = '20'
+        record['eng_percentage_spanish'] = '9001'
+
+        with self.assertRaises(Exception):
+            builder.add_cls(record, packet)
+
+    def test_check_cls_date(self):
+        """
+        Having a CLS with a visit date before June 1, 2017 raises an exception.
+        """
+        packet = ivp_packet.Packet()
+        record = make_filled_record()
+        record['visityr'] = '2016'
+
+        with self.assertRaises(Exception):
+            builder.add_cls(record, packet)
+
+
+def make_blank_record():
     return {
         'eng_preferred_language': '',
         'eng_years_speak_spanish': '',
@@ -43,8 +82,28 @@ def make_record():
         'eng_proficiency_read_english': '',
         'eng_proficiency_write_english': '',
         'eng_proficiency_oral_english': '',
-        'clslang': '0',   # This is from Form Z1X
-        'hispanic': '1',  # This is from Form A1
+        'hispanic': '',  # This is from Form A1
+    }
+
+
+def make_filled_record():
+    return {
+        'eng_preferred_language': '1',
+        'eng_years_speak_spanish': '1',
+        'eng_years_speak_english': '1',
+        'eng_percentage_spanish': '50',
+        'eng_percentage_english': '50',
+        'eng_proficiency_spanish': '1',
+        'eng_proficiency_read_spanish': '1',
+        'eng_proficiency_write_spanish': '1',
+        'eng_proficiency_oral_spanish': '1',
+        'eng_proficiency_speak_english': '1',
+        'eng_proficiency_read_english': '1',
+        'eng_proficiency_write_english': '1',
+        'eng_proficiency_oral_english': '1',
+        'hispanic': '1',
+        'visityr': '2018',
+        'visitmo': '11',
     }
 
 

--- a/tests/cls_test.py
+++ b/tests/cls_test.py
@@ -9,26 +9,43 @@ class TestCLS(unittest.TestCase):
     def test_cls_blank_not_added_to_ivp(self):
         """Don't add blank CLS form to IVP."""
         packet = ivp_packet.Packet()
-
-        record = {
-            'eng_preferred_language': '',
-            'eng_years_speak_spanish': '',
-            'eng_years_speak_english': '',
-            'eng_percentage_spanish': '',
-            'eng_percentage_english': '',
-            'eng_proficiency_spanish': '',
-            'eng_proficiency_read_spanish': '',
-            'eng_proficiency_write_spanish': '',
-            'eng_proficiency_oral_spanish': '',
-            'eng_proficiency_speak_english': '',
-            'eng_proficiency_read_english': '',
-            'eng_proficiency_write_english': '',
-            'eng_proficiency_oral_english': '',
-            'clslang': '0',
-        }
+        record = make_record()
 
         builder.add_cls(record, packet)
         self.assertEqual(len(packet), 0)
+
+    def test_cls_not_added_if_not_hispanic(self):
+        """
+        Do not add Form CLS if the subject is not Hispanic/Latino.
+
+        https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/CLS/CLS_en.pdf
+        """
+        packet = ivp_packet.Packet()
+        record = make_record()
+        record['hispanic'] = '0'  # Subject is not Hispanic/Latino.
+
+        builder.add_cls(record, packet)
+        self.assertEqual(len(packet), 0)
+
+
+def make_record():
+    return {
+        'eng_preferred_language': '',
+        'eng_years_speak_spanish': '',
+        'eng_years_speak_english': '',
+        'eng_percentage_spanish': '',
+        'eng_percentage_english': '',
+        'eng_proficiency_spanish': '',
+        'eng_proficiency_read_spanish': '',
+        'eng_proficiency_write_spanish': '',
+        'eng_proficiency_oral_spanish': '',
+        'eng_proficiency_speak_english': '',
+        'eng_proficiency_read_english': '',
+        'eng_proficiency_write_english': '',
+        'eng_proficiency_oral_english': '',
+        'clslang': '0',   # This is from Form Z1X
+        'hispanic': '1',  # This is from Form A1
+    }
 
 
 if __name__ == "__main__":

--- a/tests/cls_test.py
+++ b/tests/cls_test.py
@@ -1,0 +1,35 @@
+import unittest
+
+from nacc.uds3 import packet as ivp_packet
+from nacc.uds3.ivp import builder
+
+
+class TestCLS(unittest.TestCase):
+
+    def test_cls_blank_not_added_to_ivp(self):
+        """Don't add blank CLS form to IVP."""
+        packet = ivp_packet.Packet()
+
+        record = {
+            'eng_preferred_language': '',
+            'eng_years_speak_spanish': '',
+            'eng_years_speak_english': '',
+            'eng_percentage_spanish': '',
+            'eng_percentage_english': '',
+            'eng_proficiency_spanish': '',
+            'eng_proficiency_read_spanish': '',
+            'eng_proficiency_write_spanish': '',
+            'eng_proficiency_oral_spanish': '',
+            'eng_proficiency_speak_english': '',
+            'eng_proficiency_read_english': '',
+            'eng_proficiency_write_english': '',
+            'eng_proficiency_oral_english': '',
+            'clslang': '0',
+        }
+
+        builder.add_cls(record, packet)
+        self.assertEqual(len(packet), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@naomidb and I pair programmed this one.

We added several unit tests to handle the various cases of when to include CLS to both IVP and FVP. We also tested locally with realistic data by running the filters then nacculator itself in both IVP and FVP mode.

* CLS is only expected when the subject has indicated they are _Hispanic/Latino_.
* Errors occur when the CLS form is partially filled, not marked completed in REDCap, and when visit is before the introduction of the CLS form.