### PR TITLE
Add check_characters function to redcap2nacc

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -28,7 +28,6 @@ def check_blanks(packet, options):
     """
     Parses rules for when each field should be blank and then checks them
     """
-    pattern = re.compile(r"Blank if Question \d+ (\w+) (ne|=) (\d+)")
     warnings = []
 
     for form in packet:
@@ -55,6 +54,54 @@ def check_blanks(packet, options):
 
     return warnings
 
+
+def check_characters(packet):
+    """
+    Checks fields for any of 4 special characters: & ' " %
+    If these characters are found, throws an error and skips the ptid.
+    """
+    # In the future, might be good to search only "Char" fields if possible.
+    warnings = []
+
+    for form in packet:
+        # Find all fields that have any of the forbidden characters, and
+        #   figure out which characters are present in the string.
+        # If they are found, append an error to our error file and skip the PTID
+        for field in [f for f in form.fields.values()]:
+            chars = ['\'', '\"','&','%%']
+
+            if any((c in chars) for c in field.value):
+                quote = re.search('\'', field.value)
+                dquote = re.search('\"', field.value)
+                amp = re.search('&', field.value)
+                percent = re.search('%', field.value)
+
+                incompatible = []
+                if quote:
+                    quote = "'"
+                    incompatible.append(quote)
+                
+                if dquote:
+                    dquote = '"'
+                    incompatible.append(dquote)
+                
+                if amp:
+                    amp = '&'
+                    incompatible.append(amp)
+                
+                if percent:
+                    percent = '%'
+                    incompatible.append(percent)
+                
+                space = " "
+                character = space.join(incompatible)
+
+                warnings.append(
+                    "\'%s\' is \'%s\', which has invalid character(s) %s . This field can have any text or numbers, but cannot include single quotes \', double quotes \", ampersands & or percentage signs %% " %
+                    (field.name, field.value, character))
+    
+    return warnings
+                
 
 def check_single_select(packet):
     """ Checks the values of sets of interdependent questions
@@ -194,17 +241,27 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             traceback.print_exc()
             continue
 
+        try:
+            warnings += check_characters(packet)
+        except KeyError:
+            print("[SKIP] Error for ptid : " + str(record['ptid']), file=err)
+            traceback.print_exc()
+            continue
+
         if not options.np and not options.m and not options.lbd: 
             warnings += check_single_select(packet)
 
         if warnings:
+            print("[SKIP] Error for ptid : " + str(record['ptid']), file=err)
+            traceback.print_exc()
             print("\n".join(warnings), file=err)
+            continue
 
         for form in packet:
             
             try:
                 print(form, file=out)
-            except AssertionError as e:
+            except AssertionError:
                 print("[SKIP] Error for ptid : " + str(record['ptid']), file=err)
                 traceback.print_exc()
                 continue


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

This feature adds a "check_characters" function ( beginning line 58) to redcap2nacc that searches the fields in each form. If it finds characters incompatible with NACC ( ' " & % ) it returns an error and skips to the next ptid. In order to print the [SKIP] notification, I changed the "if warnings:" statement (line 254) in the "convert" function to skip ptids with any warnings attached.
I also deleted two unused variables "pattern" and "e" as per the linter's request and made sure the program still ran without them.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

[Issue 86](https://github.com/ctsit/nacculator/issues/86)


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the command-line, run ... (ran using vscode debugger with data.csv, which was made from my collection of REDCap sample data)
2. The output should look like this: A regular data.txt redcap2nacc output file.
3. If you pass _some bad value_, the output should look like this: Error is given in the terminal (for example): 
[SKIP] ptid : 10000
"'FIELDNAME' is 'VA&L"UE', which has invalid character(s) " & . This field can have any text or numbers, but cannot include single quotes ', double quotes ", ampersands & or percentage signs % "
4. Pylinter returns no errors or warnings, and I ran sample data through redcap2nacc with ivp, fvp, np, lbd-ivp, and lbd-fvp formats. The output of each file did not change from last time, when I finished the LBD module, so it is behaving as expected. The check_characters function is capable of finding any combination of character errors in each field, but does not keep track of further instances of the same character. So, if something like "the" is in the field, the checker will return that there is a " character in the field, but does not specify that there are two.

- Verify the thing does this: Successfully finds any of the four invalid characters in a string.
- Verify the thing does not do that: Does not return false positives, nor errors due to multiple invalid characters in one string.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [+] I matched the style of the existing code.
* [ ] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
- CHANGELOG has not been updated in a long time, but can be updated during code review.
* [+] I used Python's type hinting.
* [+] I ran the automated tests and ensured they **ALL** passed.
* [+] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [+] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [+] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
- Originally cloned from my repository and it caused issues with the commits. This branch is collected in one single commit, but there is only one file that is changed.
* [+] I have written the code myself or have given credit where credit is due.
