### PR TITLE
Modify API response processing to account for python 3 changes

### DIFF
--- a/run_filters.py
+++ b/run_filters.py
@@ -103,7 +103,7 @@ def get_data_from_redcap(folder_name, config):
                                               'format': 'csv'
                                           })
     try:
-        rawdata = str(res.content).encode("utf-8")
+        rawdata = str(res.text)
         myreader = csv.reader(rawdata.splitlines())
         try:
             with open(os.path.join(folder_name, "redcap_input.csv"),"w") as file:


### PR DESCRIPTION
Upgrading Cappy to Python3 has resulted in res.content having escaped new line characters, affecting how the csv reader processes the response. Using res.text instead emulated the previous format.

## Verification

Prior to these changes, the redcap_data.csv file was empty. After these changes, the csv is properly filled in and the rest of the NACCulator process can be done. There are also no pre-upload errors given by NACC.

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [X] I matched the style of the existing code.
* [X] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [X] I used Python's type hinting.
* [X] I ran the automated tests and ensured they **ALL** passed.
* [X] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [X] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [X] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [X] I have written the code myself or have given credit where credit is due.
