### PR TITLE
Fix Generator Tool

### DIFF
--- a/tools/generator.py
+++ b/tools/generator.py
@@ -68,7 +68,7 @@ def generate(ded):
             field = DynamicObject()
             field.name = MethodField(record['Data Element'])
             field.order = record['Data Order']
-            field.type = record['Data type']
+            field.type = record['Data Type']
             field.length = record['Data Length']
             field.position = (int(record['Column 1']), int(record['Column 2']))
             if record['RANGE1'] not in ('', '.'):

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -4,31 +4,77 @@
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
 
+"""Copyright 2015-2019 University of Florida
+
+Usage: python3 tools/generator.py -h|--help
+       python3 tools/generator.py <deds>
+       python3 tools/generator.py <deds> <header>
+       python3 tools/generator.py <deds> <header> <corrections>
+
+Form Generator creates Python code from NACC Data Element Dictionaries stored
+as CSV files.
+
+  deds         Path to the directory containing the DED CSV files
+  header       Filename of the header file within <deds>
+               Defaults to "uds3dedheader.csv".
+  corrections  Path to the directory containing manually corrected DED CSVs
+               If unspecified, checking for corrected CSVs is skipped.
+
+Note: the CSV versions of the DEDs are found on the NACC website with the form.
+For example, UDS3 FVP Form A1 is at:
+    https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/uds3dedA1FVP.csv
+"""
+
 import csv
 import os
 import re
 import sys
+import typing
 
 
-class DynamicObject(object):
-    ''' Extension to the standard object class
-    Mainly used to allow dynamic addition of members. '''
+class DynamicObject:
+    """
+    Extension to the standard object to support adding members at runtime.
+
+    ```
+    foo = object()
+    foo.bar = 42  # raises an AttributeError
+    foo = DynamicObject()
+    foo.bar = 42  # Works!
+    ```
+    """
     pass
 
 
 class MethodField(str):
-    ''' Allows for a method to be used in str.format() like a field '''
+    """ Allows a method to be used in `str.format()` like a field """
 
     @property
     def method(self):
-        l = self.lower()
-        if l in ['del']:
-            l += "_"
-        return l
+        string = self.lower()
+        if string in ["del"]:
+            string += "_"
+        return string
 
 
-def form_to_string(form, class_prefix=''):
-    ''' Returns headers with "self.fields" Python tags '''
+def fields_to_strings(fields, this="self.") -> typing.Iterable[str]:
+    """ Returns fields as a Python variable declaration """
+    for field in fields:
+        code = (
+            '{qualifier}fields["{field.name}"] = nacc.uds3.Field('
+            'name="{field.name}", '
+            'typename="{field.type}", '
+            'position={field.position}, '
+            'length={field.length}, '
+            'inclusive_range={field.inclusive_range}, '
+            'allowable_values={field.allowable_codes}, '
+            'blanks={field.blanks})'
+        ).format(qualifier=this, field=field)
+        yield code
+
+
+def form_to_string(form: DynamicObject, class_prefix: str = "") -> str:
+    """ Returns headers with "self.fields" Python tags """
 
     return f"""
 class Form{form.id}(nacc.uds3.FieldBag):
@@ -37,168 +83,136 @@ class Form{form.id}(nacc.uds3.FieldBag):
     """.strip()
 
 
-def fields_to_strings(fields, this="self."):
-    ''' Returns fields in Python formatting '''
-
-    for field in fields:
-        yield ("{qualifier}fields['{field.name}'] = nacc.uds3.Field("
-               "name='{field.name}', "
-               "typename='{field.type}', "
-               "position={field.position}, "
-               "length={field.length}, "
-               "inclusive_range={field.inclusive_range}, "
-               "allowable_values={field.allowable_codes}, "
-               "blanks={field.blanks})"
-               ).format(qualifier=this, field=field)
-
-
-def generate(ded: str, encoding: str = 'utf-8'):
-    ''' Generates Python code representing each NACC Form as classes '''
+def generate(ded: str, encoding: str = "utf-8"):
+    """ Generates Python code representing each NACC Form as a class """
 
     try:
-        stream = open(ded, encoding=encoding)
+        with open(ded, encoding=encoding) as stream:
+            reader = csv.DictReader(stream)
+            form = DynamicObject()
+            form.fields = []
 
-        # Opens the specified dictionary based on the variable "header_file"
-        # and creates form fields based on the headers in the first row.
-        # These fields are first put into the "field" object, and then
-        # appended to "form" at the end.
-        # These headers within the .csv file need to match the fields exactly.
-        reader = csv.DictReader(stream)
-        form = DynamicObject()
-        form.fields = []
+            for record in reader:
+                form.packet = record["Packet"]
+                form.id = record["Form ID"]
 
-        for record in reader:
-            form.packet = record['Packet']
-            form.id = record['Form ID']
+                field = DynamicObject()
+                field.name = MethodField(record["Data Element"])
+                field.order = record["Data Order"]
+                field.type = record["Data Type"]
+                field.length = record["Data Length"]
+                field.position = \
+                    (int(record["Column 1"]), int(record["Column 2"]))
+                if record["RANGE1"] not in ("", "."):
+                    field.inclusive_range = \
+                        (int(record["RANGE1"]), int(record["RANGE2"]))
+                else:
+                    field.inclusive_range = None
 
-            field = DynamicObject()
-            field.name = MethodField(record['Data Element'])
-            field.order = record['Data Order']
-            field.type = record['Data Type']
-            field.length = record['Data Length']
-            field.position = (int(record['Column 1']), int(record['Column 2']))
-            if record['RANGE1'] not in ('', '.'):
-                field.inclusive_range = (int(record['RANGE1']),
-                                         int(record['RANGE2']))
-            else:
-                field.inclusive_range = None
-            field.allowable_codes = [_f for _f in [code for key, code in
-                                            record.items()
-                                            if re.match('^VAL\d\d?$', str(
-                                                   key)) and code != '.'] if _f]
+                field.allowable_codes = []
+                for key, code in record.items():
+                    if not code or code == ".":
+                        continue
+                    if not re.match(r"^VAL\d\d?$", str(key)):
+                        continue
+                    field.allowable_codes.append(code)
 
-            form.fields.append(field)
-            field.blanks = [record[f] for f in reader.fieldnames
-                            if 'BLANKS' in f and record[f]]
+                form.fields.append(field)
+                field.blanks = [record[f] for f in reader.fieldnames
+                                if "BLANKS" in f and record[f]]
 
-        form.fields.sort(key=lambda f: f.order)
+            form.fields.sort(key=lambda f: f.order)
 
     except UnicodeDecodeError as err:
-        if encoding != 'windows-1252':
-            return generate(ded, 'windows-1252')
+        if encoding != "windows-1252":
+            return generate(ded, "windows-1252")
         raise err
-    finally:
-        stream.close()
 
     return form
 
 
-def generate_header(ded):
-    ''' Calls the generate function, creates the "form" object,
-        and adds the id "Header" to it. '''
-    form = generate(ded)
-    form.id = "Header"
-    return form
-
-
-def indent(text, times=1, tab='    '):
-    ''' Returns indented text
-    Inserts times number of tabs for each line and at the beginning '''
+def indent(text, times=1, tab="    "):
+    """ Returns text with times-tabs inserted at the beginning of each line """
     if not text:
-        return ''
+        return ""
 
     tabs = tab * times
-    return tabs + text.replace('\n', "\n%s" % tabs)
-
-
-def retab(text, newtab='    ', oldtab='\t'):
-    ''' Replaces all occurrences of oldtab with newtab '''
-    return text.replace(oldtab, newtab)
-
-
-def fields_for_records(form, fields):
-    ''' Adds Python formatting to the strings in the "form" object '''
-
-    formId = form.id.lower()
-    print(indent("\n\n"+formId+" = fvp_forms.Form"+form.id+"()", 1), file=sys.stderr)
-    for field in fields:
-        print(indent(formId+'{0: <10}'.format("." + field.name) +
-            " = record['fu_"+field.name.lower()+"']", 1), file=sys.stderr)
-    print(indent("packet.append("+formId+")", 1), file=sys.stderr)
+    return tabs + text.replace("\n", f"\n{tabs}")
 
 
 def main():
-    # Can take user input. The two arguments
-    # you need are "data_dict_path" and "header_file" -
-    # first to name the path to the directory of the ded you're running this
-    # generator on, and the second to name the specific file.
-    # "corrected_dict_path" is set to use the /corrected folder within
-    # "~/nacc_code/nacculator/tools",
-    # which is where the generator.py is located.
-    # The values given below are what the defaults are currently set to.
+    """ Program entry """
 
-    data_dict_path = './ded_fvp'
-    corrected_dict_path = './corrected/'
-    header_file = 'uds3dedheader.csv'
+    deds_path = ""
+    ded_header = "uds3dedheader.csv"
+    corrected_path = ""
 
-    # The "if" statement here allows for two arguments when calling
-    # generator.py from the terminal.
+    if len(sys.argv) < 2:
+        usage()
+        sys.exit(2)
+
+    if sys.argv[1] in ["-h", "--help"]:
+        usage()
+        sys.exit(0)
+
     if len(sys.argv) > 1:
-        data_dict_path = sys.argv[1]
+        deds_path = sys.argv[1]
 
     if len(sys.argv) > 2:
-        header_file = sys.argv[2]
+        ded_header = sys.argv[2]
 
-    # "deds" searches the data_dict_path and adds any .csv files
-    # that are not your header file in that directory
-    deds = [f for f in os.listdir(data_dict_path)
-            if f.endswith('.csv') and f != header_file]
+    if len(sys.argv) > 3:
+        corrected_path = sys.argv[3]
 
-    # This block provides the beginning text in the generated .py output
-    # so that the generated code can run basically right away.
-    print("import nacc.uds3")
-    print("")
-    print("")
-    header = generate_header(os.path.join(data_dict_path, header_file))
-    print("def header_fields():")
-    print((indent("fields = {}")))
-    for field in fields_to_strings(sorted(header.fields,
-                                          key=lambda fld: fld.position[1]),
-                                   this=""):
-        print((indent(field)))
-    print((indent("return fields")))
+    # Search deds_path for CSV files, excluding the ded_header.
+    deds = [filename for filename in os.listdir(deds_path)
+            if filename.endswith(".csv") and filename != ded_header]
+
+    # Generate the Python module starting with the preamble, then the common
+    # header fields, and finally the classes which represents the Forms.
+    print("""# Generated using the NACCulator form generator tool.
+import nacc.uds3
+
+
+def header_fields():
+    fields = {}""")
+
+    header = generate(os.path.join(deds_path, ded_header))
+    fields = sort_by_starting_position(header.fields)
+    fields = fields_to_strings(fields, this="")
+    for field in fields:
+        print(indent(field))
+    print(indent("return fields"))
     print("")
 
     for ded in deds:
-        # First check to see if we have a correct version of the DED
-        dedpath = os.path.join(corrected_dict_path, ded)
-        if not os.path.isfile(dedpath):
-            # If not, then we use the regular path
-            dedpath = os.path.join(data_dict_path, ded)
+        dedpath = os.path.join(deds_path, ded)
+        if corrected_path:
+            corrected = os.path.join(corrected_path, ded)
+            if os.path.isfile(corrected):
+                dedpath = corrected
 
-        print("")
         form = generate(dedpath)
-        # Uncomment this method if you want to print the templates
-        # to read records. Keys have to be filled manually as per your csv
-        # header names. To seperate this from the normal output, this prints to
-        # standard error
-        # fields_for_records(form, sorted(form.fields, key=lambda fld: fld.position[1]))
+        fields = sort_by_starting_position(form.fields)
+        fields = fields_to_strings(fields)
 
+        print("")
         print(form_to_string(form))
-        for field in fields_to_strings(sorted(form.fields, key=lambda fld: fld.position[1])):
-            print((indent(field, 2)))
+        for field in fields:
+            print(indent(field, 2))
         print("")
 
 
-if __name__ == '__main__':
+def sort_by_starting_position(fields: typing.List[DynamicObject]) \
+        -> typing.List[DynamicObject]:
+    """ Sorts fields by their starting positions """
+    return sorted(fields, key=lambda field: field.position[1])
+
+
+def usage():
+    """ Prints the usage text """
+    print(__doc__, file=sys.stderr)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
**What does this change do?**

The generator tool was created to generate Python classes for each NACC form. With minor edits, its output was intended to become the `forms.py` files.

These changes update it for Python 3 and better adhere to CTS-IT programming standards.

**Why was this change made?**

To fix #96 


## Verification

I ran the steps listed in #96. The only difference between the old code and the new is the order of some `allowable_values`. I suspect this is due to the differences in stable sorting of lists between Python 2 and 3, but it will have no affect on the code as the order shouldn't matter.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [ ] I matched the style of the existing code. *I rewrote it, so this doesn't apply*
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
