### PR TITLE
Add support to the form generator for the new CSV format

### DIFF
--- a/tests/generator_test.py
+++ b/tests/generator_test.py
@@ -1,0 +1,30 @@
+import csv
+import io
+import unittest
+
+from tools import generator
+
+
+class TestGenerator(unittest.TestCase):
+
+    def test_new_format(self):
+        a1_ivp_sample = """
+"DORDER","ITEM","VAR","PACKET","FLDLENG","COLUMN1","COLUMN2","DTYPE","RANGE","VALUES","VAL1D","VAL2D","VAL3D","VAL4D","VAL5D","VAL6D","VAL7D","VAL8D","VAL9D","VAL10D","MISSVALS","NEWQUEST","BLANKS"
+"1","1","REASON","I",1,45,45,1,"1||4","1||2||4||9","To participate in a research study","To have a clinical evaluation","Both (to participate in a research study and to have a clinical evaluation)","Unknown",,,,,,,"9","Primary reason for coming to ADC:",
+        """.strip()
+
+        expected = """
+fields["REASON"] = nacc.uds3.Field(name="REASON", typename="Num", position=(45, 45), length=1, inclusive_range=(1, 4), allowable_values=['1', '2', '4', '9'], blanks=[])
+        """.strip()
+
+        reader = io.StringIO(a1_ivp_sample)
+        reader = csv.DictReader(reader)
+        forms = generator.generate_form("", reader)
+        fields = generator.fields_to_strings(forms.fields, "")
+        actual = next(fields)
+
+        self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -20,9 +20,8 @@ as CSV files.
   corrections  Path to the directory containing manually corrected DED CSVs
                If unspecified, checking for corrected CSVs is skipped.
 
-Note: the CSV versions of the DEDs are found on the NACC website with the form.
-For example, UDS3 FVP Form A1 is at:
-    https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/uds3dedA1FVP.csv
+Note: the CSV versions of the DEDs are found on the NACC website with the form:
+    https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/UDS3csvded.html
 """
 
 import csv
@@ -60,16 +59,20 @@ class MethodField(str):
 def fields_to_strings(fields, this="self.") -> typing.Iterable[str]:
     """ Returns fields as a Python variable declaration """
     for field in fields:
+        inclusive_range = field.inclusive_range
+        if inclusive_range:
+            inclusive_range = f"({inclusive_range[0]}, {inclusive_range[1]})"
+
         code = (
             '{qualifier}fields["{field.name}"] = nacc.uds3.Field('
             'name="{field.name}", '
             'typename="{field.type}", '
             'position={field.position}, '
             'length={field.length}, '
-            'inclusive_range={field.inclusive_range}, '
+            'inclusive_range={inclusive_range}, '
             'allowable_values={field.allowable_codes}, '
             'blanks={field.blanks})'
-        ).format(qualifier=this, field=field)
+        ).format(qualifier=this, field=field, inclusive_range=inclusive_range)
         yield code
 
 
@@ -83,7 +86,7 @@ class Form{form.id}(nacc.uds3.FieldBag):
     """.strip()
 
 
-def generate(ded: str, encoding: str = "utf-8"):
+def generate(ded: str, encoding: str = "utf-8") -> DynamicObject:
     """ Generates Python code representing each NACC Form as a class """
 
     try:
@@ -93,29 +96,39 @@ def generate(ded: str, encoding: str = "utf-8"):
             form.fields = []
 
             for record in reader:
-                form.packet = record["Packet"]
-                form.id = record["Form ID"]
+                form.packet = record["PACKET"]
+
+                form.id = os.path.basename(ded)
+                form.id = form.id.replace(f"ded{form.packet}", "")
+                form.id = form.id.replace(f".csv", "")
 
                 field = DynamicObject()
-                field.name = MethodField(record["Data Element"])
-                field.order = record["Data Order"]
-                field.type = record["Data Type"]
-                field.length = record["Data Length"]
+                field.name = MethodField(record["VAR"])
+                field.order = record["DORDER"]
+
+                # TODO: Ask NACC about DTYPE. PDFs say "Num" or "Char"
+                field.type = "Num"
+                if record["DTYPE"] == "3":
+                    field.type = "Char"
+                field.length = record["FLDLENG"]
                 field.position = \
-                    (int(record["Column 1"]), int(record["Column 2"]))
-                if record["RANGE1"] not in ("", "."):
-                    field.inclusive_range = \
-                        (int(record["RANGE1"]), int(record["RANGE2"]))
-                else:
-                    field.inclusive_range = None
+                    (int(record["COLUMN1"]), int(record["COLUMN2"]))
+
+                field.inclusive_range = None
+                if record["RANGE"]:
+                    (start, end) = record["RANGE"].split("||")
+                    start = start.replace("current year", "CURRENT_YEAR")
+                    start = start.replace(" minus ", " - ")
+                    end = end.replace("current year", "CURRENT_YEAR")
+                    end = end.replace(" minus ", " - ")
+
+                    field.inclusive_range = (start, end)
 
                 field.allowable_codes = []
-                for key, code in record.items():
-                    if not code or code == ".":
-                        continue
-                    if not re.match(r"^VAL\d\d?$", str(key)):
-                        continue
+                for code in record["VALUES"].split("||"):
                     field.allowable_codes.append(code)
+
+                # TODO: handle acceptable MISSING values
 
                 form.fields.append(field)
                 field.blanks = [record[f] for f in reader.fieldnames
@@ -127,6 +140,48 @@ def generate(ded: str, encoding: str = "utf-8"):
         if encoding != "windows-1252":
             return generate(ded, "windows-1252")
         raise err
+
+    return form
+
+
+def generate_header(path: str) -> DynamicObject:
+    with open(path) as stream:
+        reader = csv.DictReader(stream)
+        form = DynamicObject()
+        form.fields = []
+
+        for record in reader:
+            form.packet = record["Packet"]
+            form.id = record["Form ID"]
+
+            field = DynamicObject()
+            field.name = MethodField(record["Data Element"])
+            field.order = record["Data Order"]
+            field.type = record["Data Type"]
+            field.length = record["Data Length"]
+            field.position = \
+                (int(record["Column 1"]), int(record["Column 2"]))
+            if record["RANGE1"] not in ("", "."):
+                (start, end) = (record["RANGE1"], record["RANGE2"])
+                if end == "2014":
+                    end = "CURRENT_YEAR"
+                field.inclusive_range = (start, end)
+            else:
+                field.inclusive_range = None
+
+            field.allowable_codes = []
+            for key, code in record.items():
+                if not code or code == ".":
+                    continue
+                if not re.match(r"^VAL\d\d?$", str(key)):
+                    continue
+                    field.allowable_codes.append(code)
+
+            form.fields.append(field)
+            field.blanks = [record[f] for f in reader.fieldnames
+                            if "BLANKS" in f and record[f]]
+
+        form.fields.sort(key=lambda f: f.order)
 
     return form
 
@@ -167,17 +222,23 @@ def main():
     # Search deds_path for CSV files, excluding the ded_header.
     deds = [filename for filename in os.listdir(deds_path)
             if filename.endswith(".csv") and filename != ded_header]
+    deds = sorted(deds)
 
     # Generate the Python module starting with the preamble, then the common
     # header fields, and finally the classes which represents the Forms.
     print("""# Generated using the NACCulator form generator tool.
+from datetime import date
+
 import nacc.uds3
+
+
+CURRENT_YEAR = date.today().year
 
 
 def header_fields():
     fields = {}""")
 
-    header = generate(os.path.join(deds_path, ded_header))
+    header = generate_header(os.path.join(deds_path, ded_header))
     fields = sort_by_starting_position(header.fields)
     fields = fields_to_strings(fields, this="")
     for field in fields:


### PR DESCRIPTION
This changeset was motivated by the new CSV format for DED files from the NACC. The form generator (`tools/generator.py`) has been updated to handle it.


## Verification

1. Download the new DEDs from https://www.alz.washington.edu/NONMEMBER/UDS/DOCS/VER3/UDS3csvded.html to a folder called `uds3`.
2. Run `python3 tools/generator.py uds3/`

There should be no errors and the output should be valid Python 3 code that look like:
```python
...
class FormA1(nacc.uds3.FieldBag):
    def __init__(self):
        self.fields = header_fields()
        self.fields["REASON"] = nacc.uds3.Field(name="REASON", typename="Num", position=(45, 45), length=1, inclusive_range=(1, 4), allowable_values=['1', '2', '4', '9'], blanks=[])
...
```

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [ ] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors. _flake8 complains about long lines, but they are needed to represent the CSV data_
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
