### PR TITLE
Add NP filter to split_ivp_fvp.sh file and update NP forms

### DIFF
--- a/nacc/uds3/np/builder.py
+++ b/nacc/uds3/np/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2020 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################

--- a/nacc/uds3/np/builder.py
+++ b/nacc/uds3/np/builder.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
 
-from nacc.uds3 import blanks
 from nacc.uds3.np import forms as np_forms
 from nacc.uds3 import packet as np_packet
 
@@ -165,6 +164,7 @@ def build_uds3_np_form(record):
 
     update_header(record, packet)
     return packet
+
 
 def update_header(record, packet):
     for header in packet:

--- a/nacc/uds3/np/forms.py
+++ b/nacc/uds3/np/forms.py
@@ -16,12 +16,14 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
+
 def header_fields():
     fields = {}
     fields['FORMVER'] = nacc.uds3.Field(name='FORMVER', typename='Num', position=(906, 907), length=2, inclusive_range=(10, 10), allowable_values=[], blanks=[])
-    fields['ADCID'] = nacc.uds3.Field(name='ADCID', typename='Num', position=(1, 2), length=2, inclusive_range=(2, 38), allowable_values=[], blanks=[])
+    fields['ADCID'] = nacc.uds3.Field(name='ADCID', typename='Num', position=(1, 2), length=2, inclusive_range=(2, 43), allowable_values=[], blanks=[])
     fields['PTID'] = nacc.uds3.Field(name='PTID', typename='Char', position=(4, 13), length=10, inclusive_range=None, allowable_values=[], blanks=[])
     return fields
+
 
 class FormNP(nacc.uds3.FieldBag):
     def __init__(self):
@@ -35,7 +37,7 @@ class FormNP(nacc.uds3.FieldBag):
         self.fields['NPDODMO'] = nacc.uds3.Field(name='NPDODMO', typename='Num', position=(43, 44), length=2, inclusive_range=(1, 12), allowable_values=[], blanks=[])
         self.fields['NPDODDY'] = nacc.uds3.Field(name='NPDODDY', typename='Num', position=(46, 47), length=2, inclusive_range=(1, 31), allowable_values=[], blanks=[])
         self.fields['NPDODYR'] = nacc.uds3.Field(name='NPDODYR', typename='Num', position=(49, 52), length=4, inclusive_range=(1984, CURRENT_YEAR), allowable_values=[], blanks=[])
-        self.fields['NPPMIH'] = nacc.uds3.Field(name='NPPMIH', typename='Num', position=(54, 57), length=4, inclusive_range=(0,98.9), allowable_values=['99.9'], blanks=[])
+        self.fields['NPPMIH'] = nacc.uds3.Field(name='NPPMIH', typename='Num', position=(54, 57), length=4, inclusive_range=(0, 98.9), allowable_values=['99.9'], blanks=[])
         self.fields['NPFIX'] = nacc.uds3.Field(name='NPFIX', typename='Num', position=(59, 59), length=1, inclusive_range=(1, 2), allowable_values=['7'], blanks=[])
         self.fields['NPFIXX'] = nacc.uds3.Field(name='NPFIXX', typename='Char', position=(61, 90), length=30, inclusive_range=(), allowable_values=[], blanks=['Blank if Question 8 NPFIX ne 7 (Other)'])
         self.fields['NPWBRWT'] = nacc.uds3.Field(name='NPWBRWT', typename='Num', position=(92, 95), length=4, inclusive_range=(100, 2500), allowable_values=['9999'], blanks=[])

--- a/nacc/uds3/np/forms.py
+++ b/nacc/uds3/np/forms.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2020 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################

--- a/tools/preprocess/split_ivp_fvp.sh
+++ b/tools/preprocess/split_ivp_fvp.sh
@@ -4,3 +4,5 @@ head -n 1 $1 > initial_visits.csv
 grep "initial_visit" $1 >> initial_visits.csv
 head -n 1 $1 > followup_visits.csv
 grep "followup_visit" $1 >> followup_visits.csv
+head -n 1 $1 > neuropathology_arm_1.csv
+grep "neuropathology_arm_1" $1 >> neuropathology_arm_1.csv


### PR DESCRIPTION
This change is very simple. I added a Neuropathology packet statement to the splitting filter, so that it creates 3 files based on the packet (ivp, fvp, and np). Nacculator is run separately for each of these packets (with the -ivp, -fvp, and -np flags respectively) and that creates finished .txt files that are ready to upload to NACC.
I also cleaned up some cruft in the forms.py and builder.py files in the np folder, and updated the allowable codes for ADCID to account for all 43 centers. 

Nacculator was not previously splitting np packets from imported REDCap data the way it can for ivp and fvp packets when running the filters, and so using the -np flag was creating output .txt files that were not able to be uploaded to NACC. See [Issue 103](https://github.com/ctsit/nacculator/issues/103). This change allows np data to be processed using the same exact method as ivp and fvp during a regular NACC upload.

## Verification

1. Make sure to have a .csv file with valid REDCap data.
2. From the command-line, run 
`bash tools/preprocess/split_ivp_fvp.sh PATH/TO/YOUR/DATA.csv`
3. The output should be 3 .csv files: initial_visits.csv, followup_visits.csv, and neuropathology_arm_1.csv, each containing rows with only the relevant type of packet.
4. If you pass a csv with no relevant packets, there should be no output.

- Verify the thing does this: Creates filtered csv files to run through nacculator and upload to NACC.
- Verify the thing does not do that: Creates csv files that are incompatible with nacculator.

Note: Right now, the np packet does not record the ADCID on REDCap, and so that value is not imported into the csv file for nacculator. This is an issue that is present when the np forms are still grouped with ivp and fvp packets in the same csv file, since nacculator evaluates each row separately. Having no ADCID does not cause errors with nacculator, but it is simple to add the correct ADCID to the neuropathology_arm_1.csv file since the column is present. I don't know how beneficial it would be to add a filter that automatically adds '41' to the column, because that ID isn't correct for any other center that might use nacculator. It seems more beneficial to have that data in REDCap before the data is exported.

## Affirmations

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
