### PR TITLE
Use redcap_event_name to split visit types

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -148,26 +148,57 @@ def check_for_bad_characters(field: Field) -> typing.List:
 
 def check_redcap_event(options, record) -> bool:
     """
-    Determines if the record's redcap_event_name matches the options flag
+    Determines if the record's redcap_event_name and filled forms match the options flag
     """
     if options.lbd and options.ivp:
-        event_name = 'initial_visit' # might want to use a regex or grep instead of exact match (like in split_ivp_fvp.sh) to catch all followup visit arms. lbd and ftld data should be in a separate csv altogether, else the ivps are going to have the same event name. discuss this with kevin.
+        event_name = 'initial_visit'
+        form_match_lbd = record['lbd_ivp_b1l_complete']
+        if (form_match_lbd == '0' or form_match_lbd == ''):
+            event_match = False
+            return event_match
+        # might want to use a regex or grep instead of exact match (like in split_ivp_fvp.sh) to catch all followup visit arms. lbd and ftld data should be in a separate csv altogether, else the ivps are going to have the same event name. discuss this with kevin.
+        # it's ok if they have the same event name because the variable names are what matter when printing data. if it's looking for lbd initial visit data then it's going to search initial_visit for the lbd variables and ignore all the other ones, so you still end up with a row with all (and only) the correct processed data
     elif options.lbd and options.fvp:
         event_name = 'followup_visit'
+        form_match_lbd = record['lbd_fvp_b1l_complete']
+        if (form_match_lbd == '0' or form_match_lbd == ''):
+            event_match = False
+            return event_match
+    # TODO: add options for lbdsv (lbd short version) (this one can currently be easily filtered by formver 3.1)
     elif options.ftld and options.ivp:
         event_name = 'initial_visit'
+        form_match_ftld = record['ftld_ivp_a3a_complete']
+        if (form_match_ftld == '0' or form_match_ftld == ''):
+            event_match = False
+            return event_match
     elif options.ftld and options.fvp:
         event_name = 'followup_visit'
+        form_match_ftld = record['ftld_fvp_a3a_complete']
+        if (form_match_ftld == '0' or form_match_ftld == ''):
+            event_match = False
+            return event_match
     elif options.csf:
-        event_name = 'csf_'# (separate csv file? is this its own event or part of a visit packet? it's not in redcap, and i didn't make the test project longitudinal so there is no redcap_event_name)
+        event_name = 'csf_'
+        # (separate csv file? is this its own event or part of a visit packet? it's not in redcap, and i didn't make the test project longitudinal so there is no redcap_event_name)
     elif options.ivp:
         event_name = 'initial_visit'
+        form_match_z1 = record['ivp_z1_complete']
+        form_match_z1x = record['ivp_z1x_complete']
+        if (form_match_z1 == '0' or form_match_z1 == '') and (form_match_z1x == '0' or form_match_z1x == ''):
+            event_match = False
+            return event_match
     elif options.np:
         event_name = 'neuropath'
     elif options.fvp:
         event_name = 'followup_visit'
+        form_match_z1 = record['fvp_z1_complete']
+        form_match_z1x = record['fvp_z1x_complete']
+        if (form_match_z1 == '0' or form_match_z1 == '') and (form_match_z1x == '0' or form_match_z1x == ''):
+            event_match = False
+            return event_match
     elif options.tfp:
-        event_name = 'telephone_followup'# this one isn't actually part of redcap yet
+        event_name = 'telephone_followup'
+        # this one isn't actually part of redcap yet
     elif options.m:
         event_name = 'milestone'
 
@@ -177,7 +208,8 @@ def check_redcap_event(options, record) -> bool:
 
     # use a re.match to check that redcap_event contains event_name
     event_match = re.search(event_name, redcap_event)
-    
+
+# event_match might need to be a string instead of boolean, in order to specify which packet we are using (depending on how the packet gets sorted due to event_name and which forms have data)? or my return method needs to be a little more complex?
     return event_match
 
 

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -188,7 +188,7 @@ def check_redcap_event(options, record) -> bool:
     elif options.np:
         event_name = 'neuropath'
     elif options.tfp:
-        event_name = 'telephone_followup'
+        event_name = 'telephone'
     elif options.m:
         event_name = 'milestone'
 

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -154,58 +154,46 @@ def check_redcap_event(options, record) -> bool:
     if options.lbd and options.ivp:
         event_name = 'initial_visit'
         form_match_lbd = record['lbd_ivp_b1l_complete']
-        if (form_match_lbd == '0' or form_match_lbd == ''):
-            event_match = False
-            return event_match
+        if form_match_lbd in ['0', '']:
+            return False
     elif options.lbd and options.fvp:
         event_name = 'followup_visit'
         form_match_lbd = record['lbd_fvp_b1l_complete']
-        if (form_match_lbd == '0' or form_match_lbd == ''):
-            event_match = False
-            return event_match
+        if form_match_lbd in ['0', '']:
+            return False
     # TODO: add options for lbdsv (lbd short version)
     elif options.ftld and options.ivp:
         event_name = 'initial_visit'
         form_match_ftld = record['ftld_ivp_a3a_complete']
-        if (form_match_ftld == '0' or form_match_ftld == ''):
-            event_match = False
-            return event_match
+        if form_match_ftld in ['0', '']:
+            return False
     elif options.ftld and options.fvp:
         event_name = 'followup_visit'
         form_match_ftld = record['ftld_fvp_a3a_complete']
-        if (form_match_ftld == '0' or form_match_ftld == ''):
-            event_match = False
-            return event_match
-    # TODO: uncomment -csf option if/when it is added to the full ADRC project.
-    # Right now it is a single non-longitudinal form in a REDCap project with
-    # no redcap_event_names.
-    # elif options.csf:
-    #     event_name = 'csf_'
+        if form_match_ftld in ['0', '']:
+            return False
     elif options.ivp:
         event_name = 'initial_visit'
         form_match_z1 = record['ivp_z1_complete']
         form_match_z1x = record['ivp_z1x_complete']
-        if (form_match_z1 == '0' or form_match_z1 == '') and \
-                (form_match_z1x == '0' or form_match_z1x == ''):
-            event_match = False
-            return event_match
-    elif options.np:
-        event_name = 'neuropath'
+        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', '']:
+            return False
     elif options.fvp:
         event_name = 'followup_visit'
         form_match_z1 = record['fvp_z1_complete']
         form_match_z1x = record['fvp_z1x_complete']
-        if (form_match_z1 == '0' or form_match_z1 == '') and \
-                (form_match_z1x == '0' or form_match_z1x == ''):
-            event_match = False
-            return event_match
+        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', '']:
+            return False
+    # TODO: add -csf option if/when it is added to the full ADRC project.
+    elif options.np:
+        event_name = 'neuropath'
     elif options.tfp:
         event_name = 'telephone_followup'
     elif options.m:
         event_name = 'milestone'
 
     redcap_event = record['redcap_event_name']
-    event_match = re.search(event_name, redcap_event)
+    event_match = event_name in redcap_event
     return event_match
 
 
@@ -310,6 +298,8 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
     """Converts data in REDCap's CSV format to NACC's fixed-width format."""
     reader = csv.DictReader(fp)
     for record in reader:
+    # Right now the csf form is a single non-longitudinal form in a
+    # separate REDCap project with no redcap_event_name.
         if not options.csf:
             event_match = check_redcap_event(options, record)
             if not event_match:

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -204,8 +204,6 @@ def check_redcap_event(options, record) -> bool:
     elif options.m:
         event_name = 'milestone'
 
-    # compare event_name with redcap_event_name in record
-    # if they don't match, then reject the record (without printed statement)
     redcap_event = record['redcap_event_name']
     event_match = re.search(event_name, redcap_event)
     return event_match

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -298,8 +298,8 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
     """Converts data in REDCap's CSV format to NACC's fixed-width format."""
     reader = csv.DictReader(fp)
     for record in reader:
-    # Right now the csf form is a single non-longitudinal form in a
-    # separate REDCap project with no redcap_event_name.
+        # Right now the csf form is a single non-longitudinal form in a
+        # separate REDCap project with no redcap_event_name.
         if not options.csf:
             event_match = check_redcap_event(options, record)
             if not event_match:

--- a/nacc/uds3/m/forms.py
+++ b/nacc/uds3/m/forms.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2020 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -20,7 +20,7 @@ def header_fields(): # may not need the headers.
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMVER'] = nacc.uds3.Field(name='FORMVER', typename='Num', position=(8, 10), length=3, inclusive_range=(1, 3), allowable_values=[], blanks=[]) 
-    fields['ADCID'] = nacc.uds3.Field(name='ADCID', typename='Num', position=(12, 13), length=2, inclusive_range=(2, 38), allowable_values=[], blanks=[])
+    fields['ADCID'] = nacc.uds3.Field(name='ADCID', typename='Num', position=(12, 13), length=2, inclusive_range=(2, 41), allowable_values=[], blanks=[])
     fields['PTID'] = nacc.uds3.Field(name='PTID', typename='Char', position=(15, 24), length=10, inclusive_range=None, allowable_values=[], blanks=[])
     fields['VISITMO'] = nacc.uds3.Field(name='VISITMO', typename='Num', position=(26, 27), length=2, inclusive_range=(1, 12), allowable_values=[], blanks=[])
     fields['VISITDAY'] = nacc.uds3.Field(name='VISITDAY', typename='Num', position=(29, 30), length=2, inclusive_range=(1, 31), allowable_values=[], blanks=[])

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -15,7 +15,7 @@ class option():
 
 class TestRedcapEvent(unittest.TestCase):
     '''
-    These tests are meant to ensure that the test_redcap_event function is
+    These tests are meant to ensure that the check_redcap_event function is
     properly distinguishing between REDCap events in an imported CSV of various
     records. Ideally, redcap2nacc should only be outputting PTIDs with the
     redcap_event_name specified by the options flag (-ivp, -ldb, et cetera) and

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -58,6 +58,20 @@ class TestRedcapEvent(unittest.TestCase):
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
 
+    def test_for_not_multiple_flags(self):
+        '''
+        Checks that -ivp alone is not returned with options like -lbd -ivp.
+        '''
+        self.options.ivp = True
+        record = {'redcap_event_name': 'initial_visit_year_arm_1',
+                  'ivp_z1_complete': '', 'ivp_z1x_complete': '',
+                  'lbd_ivp_b1l_complete': '2'}
+        incorrect = check_redcap_event(self.options, record)
+
+        self.options.lbd = True
+        result = check_redcap_event(self.options, record)
+        self.assertNotEqual(incorrect, result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -1,0 +1,55 @@
+import unittest
+
+from nacc.redcap2nacc import check_redcap_event
+
+
+class option():
+    # flag = 'ivp'
+    lbd = False
+    ftld = False
+    csf = False
+    np = False
+    m = False
+    ivp = False
+    fvp = False
+
+
+class TestRedcapEvent(unittest.TestCase):
+    '''
+    These tests are meant to ensure that the test_redcap_event function is properly distinguishing between REDCap events in an imported CSV of various records. Ideally, redcap2nacc should only be outputting PTIDs with the redcap_event_name specified by the options flag (-ivp, -ldb, et cetera) and skipping all others, leaving an output .txt file with no blank lines.
+    '''
+
+    def setUp(self):
+        self.options = option()
+
+    def test_for_ivp(self):
+        '''
+        Checks that the -ivp flag with no other options returns the correct visit (not LBD IVP or FTLD IVP).
+        '''
+        self.options.ivp = True
+        record = {'redcap_event_name': 'initial_visit_year_arm_1'}
+        result = check_redcap_event(self.options, record)
+        self.assertTrue(result)
+
+    def test_for_not_ivp(self):
+        '''
+        Checks that the initial_visit is not returned when the -ivp flag is not set.
+        '''
+        self.options.fvp = True
+        record = {'redcap_event_name': 'initial_visit_year_arm_1'}
+        result = check_redcap_event(self.options, record)
+        self.assertFalse(result)
+
+    def test_for_multiple_flags(self):
+        '''
+        Checks that options like -lbd -ivp are functional.
+        '''
+        self.options.ivp = True
+        self.options.lbd = True
+        record = {'redcap_event_name': 'initial_visit_year_arm_1'}
+        result = check_redcap_event(self.options, record)
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -15,7 +15,11 @@ class option():
 
 class TestRedcapEvent(unittest.TestCase):
     '''
-    These tests are meant to ensure that the test_redcap_event function is properly distinguishing between REDCap events in an imported CSV of various records. Ideally, redcap2nacc should only be outputting PTIDs with the redcap_event_name specified by the options flag (-ivp, -ldb, et cetera) and skipping all others, leaving an output .txt file with no blank lines.
+    These tests are meant to ensure that the test_redcap_event function is
+    properly distinguishing between REDCap events in an imported CSV of various
+    records. Ideally, redcap2nacc should only be outputting PTIDs with the
+    redcap_event_name specified by the options flag (-ivp, -ldb, et cetera) and
+    skipping all others, leaving an output .txt file with no blank lines.
     '''
 
     def setUp(self):
@@ -23,19 +27,23 @@ class TestRedcapEvent(unittest.TestCase):
 
     def test_for_ivp(self):
         '''
-        Checks that the -ivp flag with no other options returns the correct visit (not LBD IVP or FTLD IVP).
+        Checks that the -ivp flag with no other options returns the correct
+        visit (not LBD IVP or FTLD IVP).
         '''
         self.options.ivp = True
-        record = {'redcap_event_name': 'initial_visit_year_arm_1', 'ivp_z1_complete': '', 'ivp_z1x_complete': '2'}
+        record = {'redcap_event_name': 'initial_visit_year_arm_1',
+                  'ivp_z1_complete': '', 'ivp_z1x_complete': '2'}
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
 
     def test_for_not_ivp(self):
         '''
-        Checks that the initial_visit is not returned when the -ivp flag is not set.
+        Checks that the initial_visit is not returned when the -ivp flag is not
+        set.
         '''
         self.options.fvp = True
-        record = {'redcap_event_name': 'initial_visit_year_arm_1', 'fvp_z1_complete': '', 'fvp_z1x_complete': ''}
+        record = {'redcap_event_name': 'initial_visit_year_arm_1',
+                  'fvp_z1_complete': '', 'fvp_z1x_complete': ''}
         result = check_redcap_event(self.options, record)
         self.assertFalse(result)
 
@@ -45,7 +53,8 @@ class TestRedcapEvent(unittest.TestCase):
         '''
         self.options.ivp = True
         self.options.lbd = True
-        record = {'redcap_event_name': 'initial_visit_year_arm_1', 'lbd_ivp_b1l_complete': '2'}
+        record = {'redcap_event_name': 'initial_visit_year_arm_1',
+                  'lbd_ivp_b1l_complete': '2'}
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
 

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -4,7 +4,6 @@ from nacc.redcap2nacc import check_redcap_event
 
 
 class option():
-    # flag = 'ivp'
     lbd = False
     ftld = False
     csf = False
@@ -27,7 +26,7 @@ class TestRedcapEvent(unittest.TestCase):
         Checks that the -ivp flag with no other options returns the correct visit (not LBD IVP or FTLD IVP).
         '''
         self.options.ivp = True
-        record = {'redcap_event_name': 'initial_visit_year_arm_1'}
+        record = {'redcap_event_name': 'initial_visit_year_arm_1', 'ivp_z1_complete': '', 'ivp_z1x_complete': '2'}
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
 
@@ -36,7 +35,7 @@ class TestRedcapEvent(unittest.TestCase):
         Checks that the initial_visit is not returned when the -ivp flag is not set.
         '''
         self.options.fvp = True
-        record = {'redcap_event_name': 'initial_visit_year_arm_1'}
+        record = {'redcap_event_name': 'initial_visit_year_arm_1', 'fvp_z1_complete': '', 'fvp_z1x_complete': ''}
         result = check_redcap_event(self.options, record)
         self.assertFalse(result)
 
@@ -46,7 +45,7 @@ class TestRedcapEvent(unittest.TestCase):
         '''
         self.options.ivp = True
         self.options.lbd = True
-        record = {'redcap_event_name': 'initial_visit_year_arm_1'}
+        record = {'redcap_event_name': 'initial_visit_year_arm_1', 'lbd_ivp_b1l_complete': '2'}
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -325,7 +325,7 @@ ptid,redcap_event_name,formver,adcid,visitmo,visitday,visityr,visitnum,initials,
 110003,followup_visit_yea_arm_1,3,99,1,1,2019,002,ABC,2
 110004,followup_visit_yea_arm_1,3,99,1,1,2019,002,ABC,2
 '''.strip()
-        
+
         fix_header_dict = {
             'ptid' : 'PTID',
             'visitmo' : 'VisitMo',
@@ -336,12 +336,12 @@ ptid,redcap_event_name,formver,adcid,visitmo,visitday,visityr,visitnum,initials,
         actual = []
         with io.StringIO(redcap_data) as data, \
                 io.StringIO("") as results:
-                
+
             filters.filter_fix_headers_do(data, fix_header_dict, results)
 
         # Reset the file position indicator so DictReader reads from the
         # beginning of the results "file".
-        
+
             results.seek(0)
             reader = csv.reader(results)
             actual = next(reader)


### PR DESCRIPTION
This change introduces a sorting algorithm for an input .csv file into the nacculator program. This means that nacculator is able to parse which records in a .csv file should be processed depending on which flags are active (-ivp vs -fvp, -ftld, and so on), and so the splitting step in the [NACC Upload Process](https://ctsit-forge.ctsi.ufl.edu/projects/adrc/wiki/NACC_Upload_Process)
`bash tools/preprocess/split_ivp_fvp.sh run_01-11-2019/final_Update.csv`
can be skipped entirely.

This change was made to make the NACC upload process smoother and easier for users. It allows users to export all the data for an ADRC REDCap project together as one .csv so that it can be run through NACCulator without the need to create separate files for each flag.


## Verification

1. From the command-line, run `source venv/bin/activate` to activate the virtual environment.
2. Run `redcap2nacc -ivp <data.csv >data.txt` with your choice of flag and input .csv file.
3. The output should look like a .txt file with no blank lines, only the correct processed forms.
4. If you pass a .csv file that does not contain the forms and redcap_event_name to match the flag, the output should be a blank file, because all records that did not match the flag's redcap_event_name were skipped.
5. The output .txt files for each flag are ready to be uploaded to NACC as usual.

- Verify the thing does this: Creates the same output .txt files as the previous version of nacculator without the need to split the REDCap .csv file beforehand.
- Verify the thing does not do that: Print blank lines for records that do not contain the expected forms.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
