### PR TITLE
Add ability to run filters on a computer-local redcap export csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,37 @@ The filters can be run all at once with your REDCap API token using:
 You can find more details on `nacculator_filters` under the section:
 HOW TO Acquire current-db-subjects.csv for the filters
 
-Or they can be run one at a time on a `.csv` file with the `-f` and `-meta`
+
+RUNNING ALL FILTERS ON A LOCAL FILE
+------------------------------------------------------
+
+REDCap has an export size limit that can be exceeded with a large project like
+the ADRC. When the size of the project surpasses the REDCap limit, the
+`nacculator_filters` command will no longer work. The data must be manually
+exported from the project in chunks (whether by event or by ptid). However you
+choose to export the data, keep in mind that all of the fields in a packet need
+to be present in the input csv you use. So, for example, the A1 and A2 forms in
+the IVP cannot be exported and run separately through NACCulator.
+
+You can still run all the filters using your config file on a REDCap-exported
+csv, even when not using `nacculator_filters`. The command to use this filter
+locally is:
+
+    $ python3 nacc/local_filters.py nacculator_cfg.ini redcap_input.csv
+
+where `redcap_input.csv` is the location of the file you want to filter. The
+filter will then run as normal, creating a `run_CURRENT-DATE` folder and
+depositing each stage of the filter process in this folder. The final output
+of the filter process is a csv file called `final_Update.csv` which can then
+be run through NACCulator.
+
+
+RUNNING INDIVIDUAL FILTERS
+------------------------------------------------------
+
+The filters can also be run one at a time on a `.csv` file with the `-f` and `-meta`
 flags.
+
 For example, to run the fixHeaders filter:
 
     $ redcap2nacc -f fixHeaders -meta nacculator_cfg.ini <data_input.csv >filtered_output.csv

--- a/nacc/local_filters.py
+++ b/nacc/local_filters.py
@@ -1,0 +1,120 @@
+import os
+import sys
+import csv
+import datetime
+import configparser
+from nacc.uds3.filters import *
+
+
+# Creating a folder which contains Intermediate files
+def recent_run_folder(out_dir):
+    # Check if directory exists. If not, create it.
+    if not os.path.exists(out_dir):
+        try:
+            os.makedirs(out_dir)
+        except Exception as e:
+            raise e
+
+
+def get_headers(input_ptr):
+    reader = csv.DictReader(input_ptr)
+    headers = reader.fieldnames
+    print(headers)
+
+
+def run_all_filters(folder_name, config, input_name):
+    # Calling Filters
+    try:
+        print("--------------Removing subjects already in current--------------------", file=sys.stderr)
+        if input_name:
+            input_path = input_name
+        else:
+            input_path = os.path.join(folder_name, "redcap_input.csv")
+        output_path = os.path.join(folder_name, "clean.csv")
+        print("Processing", file=sys.stderr)
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_clean_ptid(input_ptr, config, output_ptr)
+
+        print("--------------Replacing drug IDs--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "clean.csv")
+        output_path = os.path.join(folder_name, "drugs.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_replace_drug_id(input_ptr, config, output_ptr)
+
+        print("--------------Fixing Headers--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "drugs.csv")
+        output_path = os.path.join(folder_name, "clean_headers.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_fix_headers(input_ptr, config, output_ptr)
+
+        print("--------------Filling in Defaults--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "clean_headers.csv")
+        output_path = os.path.join(folder_name, "default.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_fill_default(input_ptr, config, output_ptr)
+
+        print("--------------Updating fields--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "default.csv")
+        output_path = os.path.join(folder_name, "update_fields.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_update_field(input_ptr, config, output_ptr)
+
+        print("--------------Fixing Visit Dates--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "update_fields.csv")
+        output_path = os.path.join(folder_name, "proper_visitdate.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_fix_visitdate(input_ptr, config, output_ptr)
+
+        print("--------------Removing Unnecessary Records--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "proper_visitdate.csv")
+        output_path = os.path.join(folder_name, "CleanedPtid_Update.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_remove_ptid(input_ptr, config, output_ptr)
+
+        print("--------------Removing Records without VisitDate--------------------", file=sys.stderr)
+        input_path = os.path.join(folder_name, "CleanedPtid_Update.csv")
+        output_path = os.path.join(folder_name, "final_Update.csv")
+        with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
+            filter_eliminate_empty_date(input_ptr, config, output_ptr)
+
+    except Exception as e:
+        print("Error in Opening a file")
+        print(e)
+
+    return
+
+
+def read_config(config_path):
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    return config
+
+
+def main():
+    currentdate = datetime.datetime.now().strftime('%m-%d-%Y')
+    folder_name = "run_" + currentdate
+    input_name = ""
+    print("Recent folder " + folder_name, file=sys.stderr)
+
+    current_directory = os.getcwd()
+    identified_folder = os.path.join(current_directory, folder_name)
+
+    if not os.path.exists(identified_folder):
+        recent_run_folder(identified_folder)
+
+    # Reading from Config and Accessing the necessary Data
+    config_path = sys.argv[1]
+    try:
+        if sys.argv[2]:
+            input_name = sys.argv[2]
+    except IndexError:
+        pass
+    # config = read_config(config_path)
+
+    run_all_filters(folder_name, config_path, input_name)
+
+    exit()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This change adds an option to filter processing that lets the user run filters on an existing csv file on their computer, rather than necessarily downloading a new redcap_input.csv file via api every time the program is called. I added a new file called `local_filters.py` for this purpose rather than editing the existing filter file because this was intended to be a quick fix until I can repair the API export.

This change was made because our REDCap project has reached the export size limit, and the nacculator_filters command can no longer export the project data. This change allows us to continue processing our center's REDCap data until I can add an incremental process to the API export.

We can refactor this code back into `nacc/run_filters.py` as a flag option rather than a separate file when time permits, as I think this option would be useful to keep in general.


## Verification

1. Download the ADRC-only dataset from REDCap by selecting "Project Exports, Reports, and Stats" from the lefthand sidebar. 
2. Within the report list, the one we will use is report number 360 "NACC Data Export"
3. Download this report.
4. Remember to ensure your nacculator_cfg.ini file is set up by following the README instructions if necessary.
5. From the command-line, run:
$ python3 nacc/local_filters.py nacculator_cfg.ini redcap_input.csv 
where `redcap_input.csv` is the path of your REDCap report file.
6. The output should look like the normal nacculator_filters output, with a folder titled "run_mm-dd-yyyy" (with the current date filled in) and a nacculator-compatible "final_Update.csv" file inside that folder. The csvs generated from running each stage of the filter process will also be present in the folder.


- Verify the thing does this: runs just like nacculator_filters except on a local file.
- Verify the thing does not do that: anything besides what nacculator_filters does.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
