### PR TITLE
Update REDCap export to handle project of any size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ HOW TO Convert from REDCap to NACC
 
 To install NACCulator, run:
 
-    $ python3 -m pip install git+https://github.com/ctsit/cappy.git@2.0.0
     $ pip3 install git+https://github.com/ctsit/nacculator.git
 
 Once the project data is exported from REDCap to the CSV file `data.csv`, run:

--- a/nacc/run_filters.py
+++ b/nacc/run_filters.py
@@ -3,7 +3,8 @@ import sys
 import csv
 import datetime
 import configparser
-from cappy import API
+# from cappy import API
+from redcap import Project
 from nacc.uds3.filters import *
 
 
@@ -88,8 +89,7 @@ def read_config(config_path):
     return config
 
 
-# Getting Data From RedCap
-def get_data_from_redcap(folder_name, config):
+def get_data_from_redcap_pycap(folder_name, config):
     # Enter the path for filters_config
     try:
         token = config.get('cappy', 'token')
@@ -99,18 +99,45 @@ def get_data_from_redcap(folder_name, config):
         print(e)
         raise e
 
-    redcap_access_api = API(token, redcap_url, 'master.yaml')
-    res = redcap_access_api.export_records(adhoc_redcap_options={
-                                              'format': 'csv'
-                                          })
+    redcap_project = Project(redcap_url, token)
+
+    # Get list of all fieldnames in project to create a csv header
+    assert hasattr(redcap_project, 'field_names')
+    header_a = getattr(redcap_project, 'field_names')
+
+    header_b = []
+    list_of_fields = redcap_project.export_field_names()
+    for field in list_of_fields:
+        header_b.append(field['export_field_name'])
+
+    header_full = list(set(header_a + header_b))
+    header_full.insert(1, 'redcap_event_name')
+
+    # Get list of all records present in project to iterate over
+    list_of_records = []
+    all_records = redcap_project.export_records(fields=['ptid'])
+    for record in all_records:
+        if record['ptid'] not in list_of_records:
+            list_of_records.append(record['ptid'])
+
+    chunked_records = []
+    # Break the list into chunks of 50
+    n = 50
+    for i in range(0, len(list_of_records), n):
+        chunked_records.append(list_of_records[i:i + n])
+
     try:
-        rawdata = str(res.text)
-        myreader = csv.reader(rawdata.splitlines())
+
         try:
-            with open(os.path.join(folder_name, "redcap_input.csv"), "w") as file:
-                writer = csv.writer(file, delimiter=',')
-                for row in myreader:
-                    writer.writerow(row)
+            with open(os.path.join(folder_name, "redcap_input.csv"), "w") as redcap_export:
+                writer = csv.DictWriter(redcap_export, fieldnames=header_full)
+                writer.writeheader()
+                # header_mapping = next(reader)
+                for current_record_chunk in chunked_records:
+                    # current_ptid = current_record_chunk['ptid']
+                    data = redcap_project.export_records(records=current_record_chunk)
+                    for row in data:
+                        writer.writerow(row)
         except Exception as e:
             print("Error in Writing")
             print(e)
@@ -136,7 +163,7 @@ def main():
     config_path = sys.argv[1]
     config = read_config(config_path)
 
-    get_data_from_redcap(folder_name, config)
+    get_data_from_redcap_pycap(folder_name, config)
     run_all_filters(folder_name, config_path)
 
     exit()

--- a/nacc/run_filters.py
+++ b/nacc/run_filters.py
@@ -3,7 +3,6 @@ import sys
 import csv
 import datetime
 import configparser
-# from cappy import API
 from redcap import Project
 from nacc.uds3.filters import *
 
@@ -92,8 +91,8 @@ def read_config(config_path):
 def get_data_from_redcap_pycap(folder_name, config):
     # Enter the path for filters_config
     try:
-        token = config.get('cappy', 'token')
-        redcap_url = config.get('cappy', 'redcap_server')
+        token = config.get('pycap', 'token')
+        redcap_url = config.get('pycap', 'redcap_server')
     except Exception as e:
         print("Please check the config file and validate all the proper fields exist", file=sys.stderr)
         print(e)

--- a/nacc/run_filters.py
+++ b/nacc/run_filters.py
@@ -133,7 +133,6 @@ def get_data_from_redcap_pycap(folder_name, config):
                 writer.writeheader()
                 # header_mapping = next(reader)
                 for current_record_chunk in chunked_records:
-                    # current_ptid = current_record_chunk['ptid']
                     data = redcap_project.export_records(records=current_record_chunk)
                     for row in data:
                         writer.writerow(row)

--- a/nacculator_cfg.ini.example
+++ b/nacculator_cfg.ini.example
@@ -1,6 +1,6 @@
 [DEFAULT]
 
-[cappy]
+[pycap]
 token: Your REDCAP Token
 redcap_server: Your Redcap Server
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "1.8.3"
+VERSION = "1.8.2"
 
 setup(
     name="nacculator",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "1.8.2"
+VERSION = "1.8.3"
 
 setup(
     name="nacculator",
@@ -31,11 +31,12 @@ setup(
         ]
     },
 
-    dependency_links=[
-        "git+https://github.com/ctsit/cappy.git@2.0.0#egg=cappy-2.0.0"
-    ],
+    # dependency_links=[
+    #     "git+https://github.com/ctsit/cappy.git@2.0.0#egg=cappy-2.0.0"
+    # ],
     install_requires=[
-        "cappy==2.0.0"
+        # "cappy==2.0.0",
+        "PyCap>=2.1.0"
     ],
 
     python_requires=">=3.6.0",

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,7 @@ setup(
         ]
     },
 
-    # dependency_links=[
-    #     "git+https://github.com/ctsit/cappy.git@2.0.0#egg=cappy-2.0.0"
-    # ],
     install_requires=[
-        # "cappy==2.0.0",
         "PyCap>=2.1.0"
     ],
 


### PR DESCRIPTION
This change switches the python library to access a REDCap project's API from cappy to PyCap. The change in libraries allows run_filters.py to chunk its REDCap exports, which means that users can export all data from a REDCap project of any size (bypassing REDCap's hard-coded single export limit of ~3 mb). It accomplishes this by exporting 50 records at a time and appending to a local csv file, rather than downloading "redcap_input.csv" directly from the REDCap server.

The user experience should not change- all the commands are the same, all the filters and the "final_Update.csv" output should be the same. The only differences are that the final_Update.csv output's columns are not in the same order as the REDCap project, and that the user will need to update their config file (by changing the "cappy" text at the top to "pycap").

This change was made because using cappy to export all records in our project stopped working when the project became too large to export all data in one batch. This change should benefit any nacculator user though, since ADRC REDCap projects are expected to grow larger over time as more participants add more records and events.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Update nacculator- set up a python 3 virtual environment, upgrade pip in the environment if needed, and then run "pip install ." in the top directory of nacculator.
2. Set up the config file if necessary. If you already have a nacculator_cfg.ini file, update the section " [cappy] " to instead be " [pycap] ".
3. From the command-line, run 
`nacculator_filters nacculator_cfg.ini`
4. The output should look like this: The normal run_filters.py output to stderr- the name of the filter being run with every record that is updated by the filter, and then at the end there should be a "run_(current date)" folder with a csv file called final_Update.csv"
5. This final_Update.csv file can be run through nacculator with the normal commands, such as:
`redcap2nacc -ivp <run_(current date)/final_Update.csv >run_(current date)/iv_nacc_complete.txt 2>run_(current date)/ivp_errors.txt`
6. If you pass data with errors, the output should look like this: errors are caught and printed to the "errors.txt" file that you specify in the nacculator command.

- Verify the thing does this: Repairs the REDCap export function of the filters.
- Verify the thing does not do that: change any other part of the NACCulator process.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
