### PR TITLE
Update in-line comments and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,13 @@ the example above shows.
   export. Currently, only `adcid` is updated.
 
 
+* **fixVisitNum**
+
+  This filter is used to ensure that the `visitnum` field is always an integer.
+  It is currently only accessible from the config file when running all
+  filters.
+
+
 * **removePtid**
 
   This filter requires a section in the config called `filter_remove_ptid` with

--- a/nacc/ftld/blanks.py
+++ b/nacc/ftld/blanks.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -12,7 +12,8 @@ import sys
 
 def convert_rule_to_python(name: str, rule: str) -> bool:
     """
-    Converts the text `rule` into a python function.
+    Converts the "rule" string into a python function using "blanks" from the
+    associated forms.py file. The fieldname being checked here is "name".
 
     The returned function accepts one argument of type `Packet`.
 
@@ -81,6 +82,11 @@ def convert_rule_to_python(name: str, rule: str) -> bool:
 
     }
 
+    # The regex needs to have a lot of flexibility due to inconsistent naming
+    # conventions in our source, NACC's Data Element Dictionary (as seen in
+    # forms.py).
+    # The FTLD packet also has a redundant rule called "Blank if question not
+    # answered" that must be parsed, but has no effect on processing.
     single_value = re.compile(
         r"Blank if( Question(s?))? *\w+(,?) (?P<key>\w+)(,?)"
         r" *(?P<eq>=|ne) (?P<value>\d+)([^-]|$)")
@@ -176,8 +182,10 @@ def _blanking_rule_check_blank_value(key, eq, value=None):
 
 
 def _blanking_rule_ftld_or2(rule):
-    """ Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
-    Along with other regular conditions """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 2 FTDSMRIO = 0 (No)':
@@ -191,8 +199,8 @@ def _blanking_rule_ftld_or2(rule):
 def _blanking_rule_ftld_or2a(rule):
     """
     Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
-    This rule has an additional condition compared to
-    the others in this form """
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 2 FTDSMRIO = 0 (No)':
@@ -206,7 +214,10 @@ def _blanking_rule_ftld_or2a(rule):
 
 
 def _blanking_rule_ftld_or3(rule):
-    """ See _blanking_rule_ftld_or2 for rules """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 3 FTDFDGPE = 0 (No)':
@@ -218,7 +229,10 @@ def _blanking_rule_ftld_or3(rule):
 
 
 def _blanking_rule_ftld_or3a(rule):
-    """ See _blanking_rule_ftld_or2a for rules """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 3 FTDFDGPE = 0 (No)':
@@ -232,7 +246,10 @@ def _blanking_rule_ftld_or3a(rule):
 
 
 def _blanking_rule_ftld_or4(rule):
-    """ See _blanking_rule_ftld_or2 for rules """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 4 FTDAMYP = 0 (No)':
@@ -244,7 +261,10 @@ def _blanking_rule_ftld_or4(rule):
 
 
 def _blanking_rule_ftld_or4a(rule):
-    """ See _blanking_rule_ftld_or2a for rules """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 4 FTDAMYP = 0 (No)':
@@ -258,7 +278,10 @@ def _blanking_rule_ftld_or4a(rule):
 
 
 def _blanking_rule_ftld_or5(rule):
-    """ See _blanking_rule_ftld_or2 for rules """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 5 FTDCBFSP = 0 (No)':
@@ -270,7 +293,10 @@ def _blanking_rule_ftld_or5(rule):
 
 
 def _blanking_rule_ftld_or5a(rule):
-    """ See _blanking_rule_ftld_or2a for rules """
+    """
+    Blank if either of 2 possibilities is true (= 0 (No) or = 9 (Unknown))
+    along with other regular conditions
+    """
     if rule == 'Blank if Question 1 FTDIDIAG = 0 (No)':
         return lambda packet: packet['FTDIDIAG'] == 0
     elif rule == 'Blank if Question 5 FTDCBFSP = 0 (No)':
@@ -311,6 +337,8 @@ def set_zeros_to_blanks(packet):
 
 def main():
     """
+    This "blanks" file concerns the FTLD packet type.
+
     Extracts all blanking rules from all DED files in a specified directory.
 
     Usage:

--- a/nacc/ftld/fvp/builder.py
+++ b/nacc/ftld/fvp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -11,7 +11,10 @@ from nacc.uds3 import packet as ftld_fvp_packet
 
 
 def build_ftld_fvp_form(record: dict, err=sys.stderr):
-    ''' Converts REDCap CSV data into a packet (list of FVP Form objects) '''
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    FVP Form objects)
+    """
     packet = ftld_fvp_packet.Packet()
 
     # Set up the forms..........
@@ -492,6 +495,7 @@ def add_e3f(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "FF"
         header.FORMID = header.form_name

--- a/nacc/ftld/fvp/forms.py
+++ b/nacc/ftld/fvp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,10 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
-# This form is for FTLD FVP
+# This form is for FTLD FVP (FrontoTemporal Lobar Followup)
 
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/ftld/ivp/builder.py
+++ b/nacc/ftld/ivp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -11,7 +11,10 @@ from nacc.uds3 import packet as ftld_ivp_packet
 
 
 def build_ftld_ivp_form(record: dict, err=sys.stderr):
-    ''' Converts REDCap CSV data into a packet (list of IVP Form objects) '''
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    IVP Form objects)
+    """
     packet = ftld_ivp_packet.Packet()
 
     # Set up the forms..........
@@ -493,6 +496,7 @@ def add_e3f(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "IF"
         header.FORMID = header.form_name

--- a/nacc/ftld/ivp/forms.py
+++ b/nacc/ftld/ivp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,10 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
-# This form is for FTLD IVP
+# This form is for FTLD IVP (FrontoTemporal Lobar Initial Visit)
 
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/ftld/packet.py
+++ b/nacc/ftld/packet.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -7,10 +7,16 @@
 
 class Packet(list):
     """
-    A collection of FTLD Forms
+    This Packet refers to a collection of FTLD Forms.
 
-    This class makes it convenient to access a field, which are all uniquely
-    named, regardless of which form they are in.
+    A Packet is a collection of Forms, each with a unique FormID. The forms
+    present depend on the packet type (determined by flag argument when
+    running the program)- UDS, LBD, FTLD, Milestone, Neuropath, COVID, and so
+    on.
+
+    This class makes it convenient to access any field and its metadata. Each
+    field is uniquely named according to NACC's Data Element Dictionary,
+    regardless of which form they are in.
     """
 
     def __init__(self):

--- a/nacc/lbd/blanks.py
+++ b/nacc/lbd/blanks.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -12,7 +12,8 @@ import sys
 
 def convert_rule_to_python(name: str, rule: str) -> bool:
     """
-    Converts the text `rule` into a python function.
+    Converts the "rule" string into a python function using "blanks" from the
+    associated forms.py file. The fieldname being checked here is "name".
 
     The returned function accepts one argument of type `Packet`.
 
@@ -46,6 +47,9 @@ def convert_rule_to_python(name: str, rule: str) -> bool:
         'LBAPAMD2': _blanking_rule_lbd,
     }
 
+    # The regex needs to have a lot of flexibility due to inconsistent naming
+    # conventions in our source, NACC's Data Element Dictionary (as seen in
+    # forms.py)
     single_value = re.compile(
         r"Blank if( Question(s?))? *\w+ (?P<key>\w+) *(?P<eq>=|ne)"
         r" (?P<value>\d+)([^-]|$)")
@@ -145,6 +149,9 @@ def set_zeros_to_blanks(packet):
 
 def main():
     """
+    This "blanks" file concerns the LBD packet types- LBD (version 3.0) and LBD
+    Short Version (version 3.1).
+
     Extracts all blanking rules from all DED files in a specified directory.
 
     Usage:

--- a/nacc/lbd/fvp/builder.py
+++ b/nacc/lbd/fvp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,7 +9,10 @@ from nacc.uds3 import packet as lbd_fvp_packet
 
 
 def build_lbd_fvp_form(record):
-    ''' Converts REDCap CSV data into a packet (list of FVP Form objects) '''
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    FVP Form objects)
+    """
     packet = lbd_fvp_packet.Packet()
 
     # Set up the forms..........
@@ -498,6 +501,7 @@ def build_lbd_fvp_form(record):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "FL"
         header.FORMID = header.form_name

--- a/nacc/lbd/fvp/forms.py
+++ b/nacc/lbd/fvp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,10 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
-# This form is for LBD FVP
+# This form is for LBD FVP (Lewy Body Followup Visits)
 
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/lbd/ivp/builder.py
+++ b/nacc/lbd/ivp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,7 +9,10 @@ from nacc.uds3 import packet as lbd_ivp_packet
 
 
 def build_lbd_ivp_form(record):
-    ''' Converts REDCap CSV data into a packet (list of IVP Form objects) '''
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    IVP Form objects)
+    """
     packet = lbd_ivp_packet.Packet()
 
     # Set up the forms..........
@@ -497,6 +500,7 @@ def build_lbd_ivp_form(record):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "IL"
         header.FORMID = header.form_name

--- a/nacc/lbd/ivp/forms.py
+++ b/nacc/lbd/ivp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,10 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
-# This form is for LBD IVP
+# This form is for LBD IVP (Lewy Body Initial Visits)
 
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/lbd/packet.py
+++ b/nacc/lbd/packet.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -7,10 +7,16 @@
 
 class Packet(list):
     """
-    A collection of LBD Forms
+    This Packet refers to a collection of LBD or LBD Short Version forms.
 
-    This class makes it convenient to access a field, which are all uniquely
-    named, regardless of which form they are in.
+    A Packet is a collection of Forms, each with a unique FormID. The forms
+    present depend on the packet type (determined by flag argument when
+    running the program)- UDS, LBD, FTLD, Milestone, Neuropath, COVID, and so
+    on.
+
+    This class makes it convenient to access any field and its metadata. Each
+    field is uniquely named according to NACC's Data Element Dictionary,
+    regardless of which form they are in.
     """
 
     def __init__(self):

--- a/nacc/lbd/v3_1/fvp/builder.py
+++ b/nacc/lbd/v3_1/fvp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,7 +9,10 @@ from nacc.uds3 import packet as lbd_short_fvp_packet
 
 
 def build_lbd_short_fvp_form(record):
-    ''' Converts REDCap CSV data into a packet (list of FVP Form objects) '''
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    FVP Form objects)
+    """
     packet = lbd_short_fvp_packet.Packet()
 
     # Set up the forms..........
@@ -479,6 +482,7 @@ def add_e3l(record,packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         if header.form_name == "Z1X":
             header.PACKET = "F"

--- a/nacc/lbd/v3_1/fvp/forms.py
+++ b/nacc/lbd/v3_1/fvp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,10 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
-# This form is for LBD FVP's short forms (version 3.1)
+# This packet is for LBD FVP's short forms (Lewy Body Follow-Up, version 3.1)
 
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/lbd/v3_1/ivp/builder.py
+++ b/nacc/lbd/v3_1/ivp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,7 +9,10 @@ from nacc.uds3 import packet as lbd_short_ivp_packet
 
 
 def build_lbd_short_ivp_form(record):
-    ''' Converts REDCap CSV data into a packet (list of IVP Form objects) '''
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    IVP Form objects)
+    """
     packet = lbd_short_ivp_packet.Packet()
 
     # Set up the forms..........
@@ -479,6 +482,7 @@ def add_e3l(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         if header.form_name == "Z1X":
             header.PACKET = "I"

--- a/nacc/lbd/v3_1/ivp/forms.py
+++ b/nacc/lbd/v3_1/ivp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2019 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,10 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
-# This form is for LBD IVP's short forms (version 3.1)
+# This form is for LBD IVP's short forms (Lewy Body Initial, version 3.1)
 
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/run_filters.py
+++ b/nacc/run_filters.py
@@ -57,14 +57,14 @@ def run_all_filters(folder_name, config):
         with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
             filter_update_field(input_ptr, config, output_ptr)
 
-        print("--------------Fixing Visit Dates--------------------", file=sys.stderr)
+        print("--------------Fixing Visit Numbers--------------------", file=sys.stderr)
         input_path = os.path.join(folder_name, "update_fields.csv")
-        output_path = os.path.join(folder_name, "proper_visitdate.csv")
+        output_path = os.path.join(folder_name, "proper_visitnum.csv")
         with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
-            filter_fix_visitdate(input_ptr, config, output_ptr)
+            filter_fix_visitnum(input_ptr, config, output_ptr)
 
         print("--------------Removing Unnecessary Records--------------------", file=sys.stderr)
-        input_path = os.path.join(folder_name, "proper_visitdate.csv")
+        input_path = os.path.join(folder_name, "proper_visitnum.csv")
         output_path = os.path.join(folder_name, "CleanedPtid_Update.csv")
         with open(output_path, 'w') as output_ptr, open(input_path, 'r') as input_ptr:
             filter_remove_ptid(input_ptr, config, output_ptr)
@@ -89,6 +89,9 @@ def read_config(config_path):
 
 
 def get_data_from_redcap_pycap(folder_name, config):
+    """
+    Uses PyCap to collect a REDCap project data export using your API token
+    """
     # Enter the path for filters_config
     try:
         token = config.get('pycap', 'token')

--- a/nacc/uds3/__init__.py
+++ b/nacc/uds3/__init__.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2021 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,6 +9,7 @@ import decimal
 
 
 class _UdsType(object):
+    """ Handles the difference between Num and Char fields """
     def __init__(self, length):
         assert length > 0
         self.length = length
@@ -45,6 +46,13 @@ UDS3_TYPES = {'Num': Num, 'Char': Char}
 
 
 class Field(object):
+    """
+    Base class for a field. Contains all metadata pertaining to that field:
+    fieldname, whether it's a number or character, length of the field and
+    which columns in the output text that the field should occupy, the range of
+    values allowed, whether there are any exact values allowed such as error
+    codes outside of the normal range, blanking rules, and the data value.
+    """
     def __init__(self, name, typename, position, length, inclusive_range=None,
                  allowable_values=None, blanks=None, value=None):
         assert allowable_values is None or \
@@ -123,7 +131,7 @@ class Field(object):
 
 
 class FieldBag(object):
-    """ Base class for Forms """
+    """ Base class for Forms; aka a bag of Fields """
     def __init__(self):
         self.fields = dict()
 

--- a/nacc/uds3/blanks.py
+++ b/nacc/uds3/blanks.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2021 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -12,7 +12,8 @@ import sys
 
 def convert_rule_to_python(name: str, rule: str) -> bool:
     """
-    Converts the text `rule` into a python function.
+    Converts the "rule" string into a python function using "blanks" from the
+    associated forms.py file. The fieldname being checked here is "name".
 
     The returned function accepts one argument of type `Packet`.
 
@@ -33,7 +34,7 @@ def convert_rule_to_python(name: str, rule: str) -> bool:
         'ZIP': _blanking_rule_dummy,
         'DECCLMOT': _blanking_rule_dummy,
         'CRAFTDRE': _blanking_rule_dummy,
-        # Neuropath skip rules
+        # Account for the Neuropath skip rules
         'NPINF': _blanking_rule_dummy,
         'NPHEMO': _blanking_rule_dummy,
         'NPOLD': _blanking_rule_dummy,
@@ -184,6 +185,9 @@ def set_zeros_to_blanks(packet):
 
 def main():
     """
+    This "blanks" file concerns the UDS3 packet types- IVP, FVP, TIP, TFP,
+    and the Milestone and Neuropath forms.
+
     Extracts all blanking rules from all DED files in a specified directory.
 
     Usage:

--- a/nacc/uds3/blanks.py
+++ b/nacc/uds3/blanks.py
@@ -58,6 +58,9 @@ def convert_rule_to_python(name: str, rule: str) -> bool:
         'TELMILE': _blanking_rule_telmile,
     }
 
+    # The regex needs to have a lot of flexibility due to inconsistent naming
+    # conventions in our source, NACC's Data Element Dictionary (as seen in
+    # forms.py)
     single_value = re.compile(
         r"Blank if( Question(s?))? *\w+\.? (?P<key>\w+) *(?P<eq>=|ne)"
         r" (?P<value>\d+)([^-]|$)")
@@ -128,25 +131,32 @@ def _blanking_rule_dummy():
 
 
 def _blanking_rule_ftldsubt():
-    # Blank if #14a PSP ne 1 and #14b CORT ne 1 and #14c FTLDMO ne 1
-    # and 14d FTLDNOS ne 1
+    """
+    Blank if #14a PSP ne 1 and #14b CORT ne 1 and #14c FTLDMO ne 1 and 
+    14d FTLDNOS ne 1 
+    """
     return lambda packet: packet['PSP'] != 1 and packet['CORT'] != 1 and \
                           packet['FTLDMO'] != 1 and packet['FTLDNOS'] != 1
 
 
 def _blanking_rule_learned():
-    # The two rules contradict each other:
-    #  - Blank if Question 2a REFERSC ne 1
-    #  - Blank if Question 2a REFERSC ne 2
-    # The intent appears to be "blank if REFERSC is 3, 4, 5, 6, 8, or 9", but
-    # that makes 6 individual blanking rules and the maximum is 5 (BLANKS1-5).
+    """
+    The two rules contradict each other:
+     - Blank if Question 2a REFERSC ne 1
+     - Blank if Question 2a REFERSC ne 2
+    
+    The intent appears to be "blank if REFERSC is 3, 4, 5, 6, 8, or 9", but
+    that makes 6 individual blanking rules and the maximum is 5 (BLANKS1-5).
+    """
     return lambda packet: packet['REFERSC'] in (3, 4, 5, 6, 8, 9)
 
 
 def _blanking_rule_telmile():
-    # 'Blank if Question 3 TELINPER = 1 (Yes)'
-    # 'Blank if Question 3 TELINPER = 9 (Unknown)'
-    # 'Blank if this is the first telephone packet submitted for the subject.'
+    """
+    'Blank if Question 3 TELINPER = 1 (Yes)'
+    'Blank if Question 3 TELINPER = 9 (Unknown)'
+    'Blank if this is the first telephone packet submitted for the subject.'
+    """
     return lambda packet: packet['TELINPER'] in (1, 9)
 
 

--- a/nacc/uds3/blanks.py
+++ b/nacc/uds3/blanks.py
@@ -132,8 +132,8 @@ def _blanking_rule_dummy():
 
 def _blanking_rule_ftldsubt():
     """
-    Blank if #14a PSP ne 1 and #14b CORT ne 1 and #14c FTLDMO ne 1 and 
-    14d FTLDNOS ne 1 
+    Blank if #14a PSP ne 1 and #14b CORT ne 1 and #14c FTLDMO ne 1 and
+    14d FTLDNOS ne 1
     """
     return lambda packet: packet['PSP'] != 1 and packet['CORT'] != 1 and \
                           packet['FTLDMO'] != 1 and packet['FTLDNOS'] != 1
@@ -144,7 +144,7 @@ def _blanking_rule_learned():
     The two rules contradict each other:
      - Blank if Question 2a REFERSC ne 1
      - Blank if Question 2a REFERSC ne 2
-    
+
     The intent appears to be "blank if REFERSC is 3, 4, 5, 6, 8, or 9", but
     that makes 6 individual blanking rules and the maximum is 5 (BLANKS1-5).
     """

--- a/nacc/uds3/clsform.py
+++ b/nacc/uds3/clsform.py
@@ -7,8 +7,8 @@ def add_cls(record, packet, forms, err=sys.stderr):
     Adds CLS form to packet.
 
     According to the IVP Guidebook (v3.0, March 2015), Form CLS should be
-    completed if the subject or co-participant indicates that the subject is
-    Hispanic/Latino.
+    completed once if the subject or co-participant indicates that the subject
+    is Hispanic/Latino.
 
     Therefore, if the subject is not Hispanic/Latino, do not add a CLS.
 

--- a/nacc/uds3/filters.py
+++ b/nacc/uds3/filters.py
@@ -33,6 +33,7 @@ def validate(func):
 
 
 def int_or_string(value, default=-1):
+    """ Ensures that the visit number is an integer value """
     try:
         returnable = int(value)
     except ValueError:
@@ -43,6 +44,7 @@ def int_or_string(value, default=-1):
 
 @validate
 def filter_clean_ptid(input_ptr, filter_config, output_ptr):
+    """ Filter for removing PTIDs already in NACC's Current Database """
     if filter_config:
         filepath = filter_config['filepath']
         with open(filepath, 'r') as nacc_packet_file:
@@ -54,11 +56,13 @@ def filter_clean_ptid(input_ptr, filter_config, output_ptr):
 
 
 def filter_clean_ptid_do(input_ptr, nacc_packet_file, output_ptr):
+    """ Carries out the Clean PTID filter after verification """
     redcap_packet_list = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(redcap_packet_list, output)
 
-    # TODO: Deal with M Flag in Current_db.csv.
+    # TODO: Create code that can handle the -m flag (using M visits in
+    # Current_db.csv)
 
     completed_subjs = defaultdict(list)
     nacc_packet_list = csv.DictReader(nacc_packet_file)
@@ -127,6 +131,7 @@ def write_headers(reader, output):
 
 @validate
 def filter_replace_drug_id(input_ptr, filter_meta, output_ptr):
+    """ Filter for ensuring that each DrugID begins with the character "d" """
     if filter_meta:
         filter_replace_drug_id_do(input_ptr, output_ptr)
     else:
@@ -135,6 +140,7 @@ def filter_replace_drug_id(input_ptr, filter_meta, output_ptr):
 
 
 def filter_replace_drug_id_do(input_ptr, output_ptr):
+    """ Carries out the Replace DrugID Filter after verification """
     reader = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(reader, output)
@@ -157,6 +163,7 @@ def filter_replace_drug_id_do(input_ptr, output_ptr):
 
 @validate
 def filter_fix_headers(input_file, header_mapping, output_file):
+    """ Filter for correcting misspelled fieldnames in the REDCap project """
     if header_mapping:
         return filter_fix_headers_do(input_file, header_mapping, output_file)
     else:
@@ -165,6 +172,7 @@ def filter_fix_headers(input_file, header_mapping, output_file):
 
 
 def filter_fix_headers_do(input_ptr, header_dictionary, output_ptr):
+    """ Carries out the Fix Headers filter after verification """
     csv_reader = csv.reader(input_ptr)
     csv_writer = csv.writer(output_ptr)
     headers = next(csv_reader)
@@ -177,6 +185,7 @@ def filter_fix_headers_do(input_ptr, header_dictionary, output_ptr):
 
 @validate
 def filter_remove_ptid(input_ptr, filter_config, output_ptr):
+    """ Filter for removing any PTID that does not match a specified format """
     if filter_config:
         return filter_remove_ptid_do(input_ptr, filter_config, output_ptr)
     else:
@@ -185,6 +194,7 @@ def filter_remove_ptid(input_ptr, filter_config, output_ptr):
 
 
 def filter_remove_ptid_do(input_ptr, filter_diction, output_ptr):
+    """ Carries out the Remove PTID filter after verification """
     regex_exp = filter_diction['ptid_format']
     good_ptids_list = load_special_case_ptid('good_ptid', filter_diction)
     bad_ptids_list = load_special_case_ptid('bad_ptid', filter_diction)
@@ -205,6 +215,7 @@ def filter_remove_ptid_do(input_ptr, filter_diction, output_ptr):
 
 @validate
 def filter_eliminate_empty_date(input_ptr, filter_meta, output_ptr):
+    """ Filter for removing rows in the csv that do not have visit dates """
     if filter_meta:
         filter_eliminate_empty_date_do(input_ptr, output_ptr)
     else:
@@ -213,6 +224,7 @@ def filter_eliminate_empty_date(input_ptr, filter_meta, output_ptr):
 
 
 def filter_eliminate_empty_date_do(input_ptr, output_ptr):
+    """ Carries out the Eliminate Empty Date filter after verification """
     reader = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(reader, output)
@@ -224,12 +236,17 @@ def filter_eliminate_empty_date_do(input_ptr, output_ptr):
 
 
 def _invalid_date(record):
+    """ Identifies whether a date field is empty """
     return (record['visitmo'] == '' or record['visitday'] == '' or
             record['visityr'] == '')
 
 
 def fill_value_of_fields(input_ptr, output_ptr, keysDict, blankCheck=False,
                          defaultCheck=False):
+    """
+    Updates field values according to filter rules and prints out how many
+    fields were changed
+    """
     reader = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(reader, output)
@@ -251,15 +268,20 @@ def fill_value_of_fields(input_ptr, output_ptr, keysDict, blankCheck=False,
 
 
 @validate
-def filter_fix_visitdate(input_ptr, filter_meta, output_ptr):
+def filter_fix_visitnum(input_ptr, filter_meta, output_ptr):
+    """
+    Filter for converting all visitdates to integers (removing trailing zeroes
+    etc)
+    """
     if filter_meta:
-        filter_fix_visitdate_do(input_ptr, output_ptr)
+        filter_fix_visitnum_do(input_ptr, output_ptr)
     else:
         skip_filter(input_ptr, output_ptr)
         return
 
 
-def filter_fix_visitdate_do(input_ptr, output_ptr):
+def filter_fix_visitnum_do(input_ptr, output_ptr):
+    """ Carries out the Fix Visitnum filter after verification """
     reader = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(reader, output)
@@ -273,15 +295,23 @@ def filter_fix_visitdate_do(input_ptr, output_ptr):
 
 @validate
 def filter_fill_default(input_ptr, filter_meta, output_ptr):
+    """
+    Hard-codes selected empty fields from the config to always be a set value
+    """
     if filter_meta:
-        fill_value_of_fields(input_ptr, output_ptr, fill_default_values(filter_meta), defaultCheck=True)
+        fill_value_of_fields(input_ptr, output_ptr,
+                             fill_default_values(filter_meta),
+                             defaultCheck=True)
     else:
         skip_filter(input_ptr, output_ptr)
         return
 
 
 def fill_default_values(config):
-    # This dictionary contains the keys used in the config
+    """
+    This dictionary contains the keys used in the config - it carries out the
+    Fill Default filter after verification
+    """
     try:
         adcid = config['adcid']
     except KeyError:
@@ -294,13 +324,20 @@ def fill_default_values(config):
 
 @validate
 def filter_update_field(input_ptr, filter_meta, output_ptr):
+    """
+    Hard-codes fields from the config that may already be filled to always be a
+    certain value
+    """
     if filter_meta:
-        fill_value_of_fields(input_ptr, output_ptr, fill_non_blank_values(filter_meta), blankCheck=True)
+        fill_value_of_fields(input_ptr, output_ptr,
+                             fill_non_blank_values(filter_meta),
+                             blankCheck=True)
     else:
         skip_filter(input_ptr, output_ptr)
 
 
 def fill_non_blank_values(config):
+    """ Carries out the Update Field filter after verification """
     try:
         adcid = config['adcid']
     except KeyError:
@@ -310,6 +347,10 @@ def fill_non_blank_values(config):
 
 
 def skip_filter(input_ptr, output_ptr):
+    """
+    Prints a confirmation that a filter has been skipped and moves on to the
+    next step in processing
+    """
     reader = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(reader, output)
@@ -320,50 +361,71 @@ def skip_filter(input_ptr, output_ptr):
 
 
 def filter_extract_ptid(input_ptr, Ptid, visit_num, visit_type, output_ptr):
+    """
+    Filter for the "getPtid" option in redcap2nacc using the -ptid, -vnum, and
+    -vtype flags. This filter collects information about a PTID in the input
+    csv file based on criteria: PTID, visit number, visit type (based on the
+    REDCap event name, such as "followup") respectively.
+    """
     reader = csv.DictReader(input_ptr)
     output = csv.DictWriter(output_ptr, None)
     write_headers(reader, output)
 
-    if(visit_num and visit_type):
+    if (visit_num and visit_type):
         filtered = [row for row in reader if
                     filter_csv_all(Ptid, visit_num, visit_type, row)]
 
-    elif(not visit_num and visit_type):
+    elif (not visit_num and visit_type):
         filtered = [row for row in reader if
                     filter_csv_vtype(Ptid, visit_type, row)]
 
-    elif(not visit_type and visit_num):
+    elif (not visit_type and visit_num):
         filtered = [row for row in reader if
                     filter_csv_vnum(Ptid, visit_num, row)]
 
-    elif(not visit_type and not visit_num):
+    elif (not visit_type and not visit_num):
         filtered = [row for row in reader if
                     filter_csv_ptid(Ptid, row)]
     output.writerows(filtered)
 
 
 def filter_csv_all(Ptid, visit_num, visit_type, record):
+    """
+    Returns records for PTIDs that match the requested PTID, visit number, AND
+    visit type
+    """
     if record['ptid'] == Ptid and record['visitnum'].lstrip("0") == visit_num \
       and (re.search(visit_type, record['redcap_event_name'])):
         return record
 
 
 def filter_csv_vtype(Ptid, visit_type, record):
+    """
+    Returns records for PTIDs that match the requested PTID and visit type
+    """
     if record['ptid'] == Ptid and re.search(visit_type, record['redcap_event_name']):
         return record
 
 
 def filter_csv_vnum(Ptid, visit_num, record):
+    """
+    Returns records for PTIDs that match the requested PTID and visit number
+    """
     if record['ptid'] == Ptid and record['visitnum'].lstrip("0") == visit_num:
         return record
 
 
 def filter_csv_ptid(Ptid, record):
+    """ Returns all records for the PTID that matches a requested PTID """
     if record['ptid'] == Ptid:
         return record
 
 
 def load_special_case_ptid(case_name, filter_config):
+    """
+    Loads bad_ptids and good_ptids into a list from the config file depending
+    on case_name input argument
+    """
     try:
         ptids_string = filter_config[case_name]
         li = list(ptids_string.split(","))

--- a/nacc/uds3/fvp/builder.py
+++ b/nacc/uds3/fvp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -12,7 +12,10 @@ from nacc.uds3 import packet as fvp_packet
 
 
 def build_uds3_fvp_form(record, err=sys.stderr):
-    """ Converts REDCap CSV data into a packet (list of FVP Form objects) """
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    FVP Form objects)
+    """
     packet = fvp_packet.Packet()
 
     # Set up the forms
@@ -1146,6 +1149,7 @@ def add_d2(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "F"
         header.FORMID = header.form_name

--- a/nacc/uds3/fvp/forms.py
+++ b/nacc/uds3/fvp/forms.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -16,8 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
+# This packet is for UDS3 FVP (Followup Visit) forms
+
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/uds3/ivp/builder.py
+++ b/nacc/uds3/ivp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -12,7 +12,10 @@ from nacc.uds3.ivp import forms as ivp_forms
 
 
 def build_uds3_ivp_form(record, err=sys.stderr):
-    """ Converts REDCap CSV data into a packet (list of IVP Form objects) """
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    IVP Form objects)
+    """
     packet = ivp_packet.Packet()
 
     # Set up the forms
@@ -1246,6 +1249,7 @@ def add_d2(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "I"
         header.FORMID = header.form_name

--- a/nacc/uds3/ivp/forms.py
+++ b/nacc/uds3/ivp/forms.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -16,6 +16,7 @@ CURRENT_YEAR = date.today().year
 
 
 class FormA4G(nacc.uds3.FieldBag):
+    """ A4 is handled separately because it is a repeatable form """
     def __init__(self):
         self.fields = header_fields()
         self.fields['ANYMEDS'] = nacc.uds3.Field(name='ANYMEDS',
@@ -25,8 +26,13 @@ class FormA4G(nacc.uds3.FieldBag):
 
 ### END non-generated code
 
+# This packet is for the UDS3 IVP (Initial Visit) forms
+
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/uds3/m/builder.py
+++ b/nacc/uds3/m/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -10,8 +10,11 @@ import re
 
 
 def build_uds3_m_form(record):
-
-    """ Converts REDCap CSV data into a packet (list of M Form objects) """
+    """
+    Converts REDCap CSV data into a packet (list of M Form objects). The
+    Milestone packet is a single form with a slightly different format than UDS
+    visit data, but it still needs header info etc.
+    """
     packet = m_packet.Packet()
     m = m_form.FormM()
     m.CHANGEMO = parse_date(record['m1_1'], 'M')

--- a/nacc/uds3/m/forms.py
+++ b/nacc/uds3/m/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,8 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
+# This packet is for M (Milestone) forms
+
 
 def header_fields():  # may not need the headers.
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/uds3/np/builder.py
+++ b/nacc/uds3/np/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,6 +9,9 @@ from nacc.uds3 import packet as np_packet
 
 
 def build_uds3_np_form(record):
+    """
+    The Neuropath packet is a single form with a different format than UDS data
+    """
     packet = np_packet.Packet()
     np = np_forms.FormNP()
     np.NPFORMMO = record['npformmo']

--- a/nacc/uds3/np/forms.py
+++ b/nacc/uds3/np/forms.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -15,6 +15,8 @@ from datetime import date
 CURRENT_YEAR = date.today().year
 
 ### END non-generated code
+
+# This packet is for NP (Neuropath) forms
 
 
 def header_fields():

--- a/nacc/uds3/packet.py
+++ b/nacc/uds3/packet.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -7,10 +7,15 @@
 
 class Packet(list):
     """
-    A collection of UDS Forms
+    A Packet is a collection of Forms, each with a unique FormID. The forms
+    present depend on the packet type (determined by flag argument when
+    running the program)- UDS, LBD, FTLD, Milestone, Neuropath, COVID, and so
+    on.
 
-    This class is makes it convenient to access a field, which are all uniquely
-    named, regardless of which form they are in with the exception of A4D.
+    This class makes it convenient to access any field and its metadata. Each
+    field is uniquely named according to NACC's Data Element Dictionary,
+    regardless of which form they are in (with the exception of A4D, which is a
+    repeating form).
     """
 
     def __init__(self):
@@ -18,7 +23,7 @@ class Packet(list):
 
     def __getitem__(self, key):
         """
-        Searches through each form in the packet for the field, `key`
+        Searches through each form in the packet for the fieldname, or `key`
 
         Note: you cannot access fields in A4D in this manner since there is no
         guarantee there will only be one; a KeyError will be raised.

--- a/nacc/uds3/packet.py
+++ b/nacc/uds3/packet.py
@@ -7,6 +7,8 @@
 
 class Packet(list):
     """
+    This Packet refers to a collection of UDS, Milestone, or Neuropath forms.
+
     A Packet is a collection of Forms, each with a unique FormID. The forms
     present depend on the packet type (determined by flag argument when
     running the program)- UDS, LBD, FTLD, Milestone, Neuropath, COVID, and so

--- a/nacc/uds3/tfp/builder.py
+++ b/nacc/uds3/tfp/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -9,7 +9,10 @@ from nacc.uds3 import packet as tfp_packet
 
 
 def build_uds3_tfp_form(record):
-    """ Converts REDCap CSV data into a packet (list of TFP Form objects) """
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    TFP Form objects)
+    """
     packet = tfp_packet.Packet()
 
     # Set up the forms
@@ -712,6 +715,7 @@ def add_z1_or_z1x(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = 'T'
         header.FORMID = header.form_name

--- a/nacc/uds3/tfp/forms.py
+++ b/nacc/uds3/tfp/forms.py
@@ -1,8 +1,9 @@
 ###############################################################################
-# Copyright 2015-2020 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
+
 import nacc.uds3
 
 ### BEGIN non-generated code
@@ -15,8 +16,13 @@ CURRENT_YEAR = date.today().year
 
 ### END non-generated code
 
+# This packet is for TFP (Telephone Followup) forms
+
 
 def header_fields():
+    """
+    Generates the header info that appears in columns 1-43 of every form
+    """
     fields = {}
     fields['PACKET'] = nacc.uds3.Field(name='PACKET', typename='Char', position=(1, 2), length=2, inclusive_range=None, allowable_values=[], blanks=[])
     fields['FORMID'] = nacc.uds3.Field(name='FORMID', typename='Char', position=(4, 6), length=3, inclusive_range=None, allowable_values=[], blanks=[])

--- a/nacc/uds3/tfp/v3_2/builder.py
+++ b/nacc/uds3/tfp/v3_2/builder.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2021 University of Florida. All rights reserved.
+# Copyright 2015-2023 University of Florida. All rights reserved.
 # This file is part of UF CTS-IT's NACCulator project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
@@ -12,7 +12,10 @@ from nacc.uds3 import packet as tfp_new_packet
 
 
 def build_uds3_tfp_new_form(record, err=sys.stderr):
-    """ Converts REDCap CSV data into a packet (list of TFP V3.2 Form objects) """
+    """
+    Populates a Packet object with a record of REDCap CSV-read data (list of
+    TFP V3.2 Form objects)
+    """
     packet = tfp_new_packet.Packet()
 
     # Set up the forms
@@ -862,6 +865,7 @@ def add_d2(record, packet):
 
 
 def update_header(record, packet):
+    """ The header must be printed for each row of text output """
     for header in packet:
         header.PACKET = "T"
         header.FORMID = header.form_name

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -105,9 +105,9 @@ ptid,redcap_event_name,formver,adcid,visitmo,visitday,visityr,visitnum,initials,
         expected = ['1600-A', '110001', '110003']
         self.assertListEqual(actual, expected)
 
-    def test_filter_fix_vistdate(self):
+    def test_filter_fix_vistnim(self):
         '''
-        `filter_fix_visitdate` should turn string to int if
+        `filter_fix_visitnum` should turn string to int if
         filled and does nothing if blank.
         '''
         redcap_data = '''
@@ -120,7 +120,7 @@ ptid,redcap_event_name,formver,adcid,visitmo,visitday,visityr,visitnum,initials,
         actual = []
         with io.StringIO(redcap_data) as data, \
                 io.StringIO("") as results:
-            filters.filter_fix_visitdate_do(data, results)
+            filters.filter_fix_visitnum_do(data, results)
 
             results.seek(0)
             reader = csv.DictReader(results)


### PR DESCRIPTION
This change will implement updates to the in-line code and docstrings attached to functions within the code. The updates on this branch are geared toward the benefit of NACCulator developers rather than users. It does not change the way NACCulator operates in any way, other than updating the title of a filter that was misleading and confusing ("fix_visitdate" to "fix_visitnum", since the filter did not actually affect the visit date at all). 

This change was made because NACCulator is a large and complicated machine, and good documentation will allow people to more quickly see how it works when they develop new functionalities. 


## Verification

After activating the python 3 virtual environment, and making sure you have the config file set up with a REDCap API token...

1. From the command line, run `python3 -m unittest` to verify all unit tests work.
2. Next, on the command line, run `nacculator_filters nacculator_cfg.ini` to automatically download the data from our REDCap project and run all filters.
3. Run `redcap2nacc -ivp <run_01-23-2023/final_Update.csv >run_01-23-2023/ivp_nacc_complete.txt 2>run_01-23-2023/ivp_errors.txt` (replacing 01-23-2023 with the current date) (or use whichever flags you like: -fvp, -tfp, -ivp -lbdsv, and so on)
4. The output should look like this: Normal NACCulator output, with an ivp_nacc_complete.txt file and ivp_errors.txt file.
5. If you pass data with errors, the output should look like this: NACCulator will catch and log the error as expected.
6. Check within the code to see that each .py file has functions with docstrings and comments that make sense and illustrate what the program is doing.
7. If you have any questions about any of the docstrings or operations that weren't explicitly described, please tell me here and I will add explanations to those parts of the code.

- Verify the thing does this: An accurate description of NACCulator's inner workings.
- Verify the thing does not do that: Change the way NACCulator works in any way.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
