### PR TITLE
Add visitnum to error and warning printouts

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -468,7 +468,8 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             if not event_match:
                 continue
 
-        print("[START] ptid : " + str(record['ptid']), file=err)
+        print("[START] ptid : " + str(record['ptid']) + " visit " +
+              str(record['visitnum']), file=err)
         try:
             if options.lbd and options.ivp:
                 packet = lbd_ivp_builder.build_lbd_ivp_form(record)
@@ -503,8 +504,8 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
 
         except Exception:
             if 'ptid' in record:
-                print("[SKIP] Error for ptid : " + str(record['ptid']),
-                      file=err)
+                print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                      " visit " + str(record['visitnum']), file=err)
             traceback.print_exc()
             continue
 
@@ -519,20 +520,22 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
         try:
             warnings += check_blanks(packet, options)
         except KeyError:
-            print("[SKIP] Error for ptid : " + str(record['ptid']), file=err)
+            print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                  " visit " + str(record['visitnum']), file=err)
             traceback.print_exc()
             continue
 
         try:
             warnings += check_characters(packet)
         except KeyError:
-            print("[SKIP] Error for ptid : " + str(record['ptid']), file=err)
+            print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                  " visit " + str(record['visitnum']), file=err)
             traceback.print_exc()
             continue
 
         if warnings:
-            print("[SKIP] Error for ptid : " + str(record['ptid']),
-                  file=err)
+            print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                  " visit " + str(record['visitnum']), file=err)
             warn = "\n".join(map(str, warnings))
             warn = warn.replace("\\", "")
             print(warn, file=err)
@@ -548,8 +551,8 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             try:
                 print(form, file=out)
             except AssertionError:
-                print("[SKIP] Error for ptid : " + str(record['ptid']),
-                      file=err)
+                print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                      " visit " + str(record['visitnum']), file=err)
                 traceback.print_exc()
                 continue
 

--- a/nacc/uds3/clsform.py
+++ b/nacc/uds3/clsform.py
@@ -52,7 +52,7 @@ def add_cls(record, packet, forms, err=sys.stderr):
     ptid = record.get('ptid', 'unknown')
     if num_filled_fields != total_fields:
         msg = "[WARNING] CLS form is incomplete for PTID: " \
-            + ptid
+            + ptid + " visit " + str(record['visitnum'])
         print(msg, file=err)
 
     # Otherwise, check percentages and dates before appending.

--- a/nacc/uds3/clsform.py
+++ b/nacc/uds3/clsform.py
@@ -61,19 +61,19 @@ def add_cls(record, packet, forms, err=sys.stderr):
     try:
         pct_spn = int(record['eng_percentage_spanish'])
     except ValueError:
-        msg = "[WARNING] eng_percentage_spanish is not an " \
+        msg = "[WARNING] CLS eng_percentage_spanish is not an " \
             "integer for PTID: " + ptid + " visit " + str(record['visitnum'])
         print(msg, file=err)
 
     try:
         pct_eng = int(record['eng_percentage_english'])
     except ValueError:
-        msg = "[WARNING] eng_percentage_english is not an " \
+        msg = "[WARNING] CLS eng_percentage_english is not an " \
             "integer for PTID: " + ptid + " visit " + str(record['visitnum'])
         print(msg, file=err)
 
     if pct_eng + pct_spn != 100:
-        msg = "[WARNING] language proficiency " + \
+        msg = "[WARNING] CLS language proficiency " + \
             "percentages do not equal 100 for PTID : " + ptid + " visit " + \
             str(record['visitnum'])
         print(msg, file=err)

--- a/nacc/uds3/clsform.py
+++ b/nacc/uds3/clsform.py
@@ -62,19 +62,20 @@ def add_cls(record, packet, forms, err=sys.stderr):
         pct_spn = int(record['eng_percentage_spanish'])
     except ValueError:
         msg = "[WARNING] eng_percentage_spanish is not an " \
-            "integer for PTID: " + ptid
+            "integer for PTID: " + ptid + " visit " + str(record['visitnum'])
         print(msg, file=err)
 
     try:
         pct_eng = int(record['eng_percentage_english'])
     except ValueError:
         msg = "[WARNING] eng_percentage_english is not an " \
-            "integer for PTID: " + ptid
+            "integer for PTID: " + ptid + " visit " + str(record['visitnum'])
         print(msg, file=err)
 
     if pct_eng + pct_spn != 100:
         msg = "[WARNING] language proficiency " + \
-            "percentages do not equal 100 for PTID : " + ptid
+            "percentages do not equal 100 for PTID : " + ptid + " visit " + \
+            str(record['visitnum'])
         print(msg, file=err)
 
     visit_date = datetime.datetime(
@@ -82,12 +83,14 @@ def add_cls(record, packet, forms, err=sys.stderr):
     cls_added = datetime.datetime(2017, 6, 1)
     if visit_date < cls_added:
         message = "CLS forms should not be in " + \
-            "packets from before June 1, 2017 for PTID: " + ptid
+            "packets from before June 1, 2017 for PTID: " + ptid + \
+            " visit " + str(record['visitnum'])
         raise Exception(message)
 
     if record['form_cls_linguistic_history_of_subject_complete'] != '2':
         message = "Could not parse packet as completed CLS form is not " + \
-            "marked complete in REDCap for PTID: " + ptid
+            "marked complete in REDCap for PTID: " + ptid + " visit " + \
+            str(record['visitnum'])
         raise Exception(message)
 
     packet.append(cls_form)

--- a/tests/test_cls.py
+++ b/tests/test_cls.py
@@ -59,13 +59,13 @@ class TestCLS(unittest.TestCase):
         ipacket = packet.Packet()
         itrap = StringIO()
         clsform.add_cls(record, ipacket, ivp_forms, itrap)
-        assert itrap.getvalue() == "[WARNING] CLS form is incomplete for PTID: unknown\n"
+        assert itrap.getvalue() == "[WARNING] CLS form is incomplete for PTID: unknown visit 1\n"
         itrap.close()
 
         fpacket = packet.Packet()
         ftrap = StringIO()
         clsform.add_cls(record, fpacket, fvp_forms, ftrap)
-        assert ftrap.getvalue() == "[WARNING] CLS form is incomplete for PTID: unknown\n"
+        assert ftrap.getvalue() == "[WARNING] CLS form is incomplete for PTID: unknown visit 1\n"
         ftrap.close()
 
     def test_cls_proficiency_not_100_has_warning(self):
@@ -80,13 +80,13 @@ class TestCLS(unittest.TestCase):
         ipacket = packet.Packet()
         itrap = StringIO()
         clsform.add_cls(record, ipacket, ivp_forms, itrap)
-        assert itrap.getvalue() == "[WARNING] language proficiency percentages do not equal 100 for PTID : unknown\n"
+        assert itrap.getvalue() == "[WARNING] CLS language proficiency percentages do not equal 100 for PTID : unknown visit 1\n"
         itrap.close()
 
         fpacket = packet.Packet()
         ftrap = StringIO()
         clsform.add_cls(record, fpacket, fvp_forms, ftrap)
-        assert ftrap.getvalue() == "[WARNING] language proficiency percentages do not equal 100 for PTID : unknown\n"
+        assert ftrap.getvalue() == "[WARNING] CLS language proficiency percentages do not equal 100 for PTID : unknown visit 1\n"
         ftrap.close()
 
     def test_check_cls_date(self):
@@ -156,6 +156,7 @@ def make_filled_record():
         'eng_proficiency_write_english': '1',
         'eng_proficiency_oral_english': '1',
         'hispanic': '1',    # This is from Form A1
+        'visitnum': '1',
         'visityr': '2018',
         'visitmo': '11',
         'form_cls_linguistic_history_of_subject_complete': '2',


### PR DESCRIPTION
This change adds a visit number to the messages that nacculator sends to stderr (such as when it's starting a new PTID, or when there's an error printout). It does not introduce any changes to how PTIDs are processed, it just adds one more piece of information to the logging.

This change was made to make it easier to track down the errors in REDCap that NACCulator reports. With a form name and visit number, it becomes easier to sleuth out what issue NACCulator is reporting so it can be quickly corrected in the REDCap project.


## Verification

1. Make sure the nacculator_cfg.ini file is set up for your local repo with a REDCap token.
2. From the command-line, run:
$ nacculator_filters nacculator_cfg.ini
to download the REDCap data.
3. Run nacculator with the -ivp or -fvp flags and examine the errors output:
$ redcap2nacc -ivp <input.csv >ivp_output.txt 2>ivp_errors.txt
4. Instead of
[START] ptid : 111111
[START] ptid : 222222
[WARNING] language proficiency percentages do not equal 100 for PTID : 222222
The output should look like this: 
[START] ptid : 111111 visit 1
[START] ptid : 222222 visit 1
[WARNING] language proficiency percentages do not equal 100 for PTID : 222222 visit 1
and so on.

- Verify the thing does this: Adds visit number to error logging
- Verify the thing does not do that: Does not change anything else about NACCulator's operations


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
