### PR TITLE
Skip Milestone forms marked "Incomplete" (0) in REDCap

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -287,6 +287,19 @@ def check_redcap_event(options, record, out=sys.stdout, err=sys.stderr) -> bool:
         event_name = 'tele'
     elif options.m:
         event_name = 'milestone'
+        try:
+            milestone_match = record['milestone_complete']
+            if milestone_match in ['', '0']:
+                return False
+        except KeyError:
+            try:
+                milestone_match = record['ee5_research_structural_mri_complete']
+                if milestone_match in ['', '0']:
+                    return False
+            except KeyError:
+                print("Could not find a REDCap field corresponding to the \
+                      Milestone form.",
+                      file=err)
 
     redcap_event = record['redcap_event_name']
     event_match = event_name in redcap_event

--- a/nacc/uds3/clsform.py
+++ b/nacc/uds3/clsform.py
@@ -54,6 +54,7 @@ def add_cls(record, packet, forms, err=sys.stderr):
         msg = "[WARNING] CLS form is incomplete for PTID: " \
             + ptid + " visit " + str(record['visitnum'])
         print(msg, file=err)
+        return
 
     # Otherwise, check percentages and dates before appending.
 

--- a/nacc/uds3/fvp/forms.py
+++ b/nacc/uds3/fvp/forms.py
@@ -57,7 +57,7 @@ class FormA2(nacc.uds3.FieldBag):
         self.fields['INBIRYR'] = nacc.uds3.Field(name='INBIRYR', typename='Num', position=(48, 51), length=4, inclusive_range=(1875, CURRENT_YEAR-15), allowable_values=['9999'], blanks=[])
         self.fields['INSEX'] = nacc.uds3.Field(name='INSEX', typename='Num', position=(53, 53), length=1, inclusive_range=(1, 2), allowable_values=['2', '1'], blanks=[])
         self.fields['NEWINF'] = nacc.uds3.Field(name='NEWINF', typename='Num', position=(55, 55), length=1, inclusive_range=(0, 1), allowable_values=['1', '0'], blanks=[])
-        self.fields['INHISP'] = nacc.uds3.Field(name='INHISP', typename='Num', position=(57, 57), length=1, inclusive_range=(0, 1), allowable_values=['1', '0'], blanks=['Blank if Question 3 NEWINF = 0 (No)'])
+        self.fields['INHISP'] = nacc.uds3.Field(name='INHISP', typename='Num', position=(57, 57), length=1, inclusive_range=(0, 1), allowable_values=['1', '0', '9'], blanks=['Blank if Question 3 NEWINF = 0 (No)'])
         self.fields['INHISPOR'] = nacc.uds3.Field(name='INHISPOR', typename='Num', position=(59, 60), length=2, inclusive_range=(1, 6), allowable_values=['50', '99', '3', '2', '1', '6', '5', '4'], blanks=['Blank if Question 4 INHISP ne 1 (Yes)'])
         self.fields['INHISPOX'] = nacc.uds3.Field(name='INHISPOX', typename='Char', position=(62, 121), length=60, inclusive_range=None, allowable_values=[], blanks=['Blank if Question 4a INHISPOR ne 50 (Other)'])
         self.fields['INRACE'] = nacc.uds3.Field(name='INRACE', typename='Num', position=(123, 124), length=2, inclusive_range=(1, 5), allowable_values=['99', '3', '2', '1', '50', '5', '4'], blanks=['Blank if Question 3 NEWINF = 0 (No)'])


### PR DESCRIPTION
**What does this change do?**

This change adds logic to redcap2nacc in the "check_redcap_event" function, specifically line 290. It checks the packet to see if the Milestone form has been marked "Incomplete" or if the form was left blank in that event. If the form completion field is marked blank or 0, the milestone form is skipped in processing. If it can't find any expected milestone form completion fields, it prints an error before defaulting to its previous behavior (processing all forms present in the Milestone events). 

**Why was this change made?** 

This change was made to address milestone forms entered in our REDCap project that were created physically but conflict with the automated milestone-filling processes. Those manually-entered forms have been recorded in REDCap but marked as "Incomplete" as they cause errors when submitting to NACC (we are keeping the automatically generated ones). 


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Ensure you have NACCulator installed locally and have your nacculator_cfg.ini file set up.
2. From the command-line, run:
$ nacculator_filters nacculator_cfg.ini
$ redcap2nacc -m <run_09-11-2023/final_Update.csv >m_test.txt
(or whatever the current date is)
3. The output should look like this: the console should print out regular milestone processing logs. The final m_test.txt file should be regular milestone output, but skipping REDCap forms that were marked Incomplete (ee5_research_structural_mri_complete = 0 in final_Update.csv)
4. If you pass _some bad value_, the output should look like this: NACCulator will print an error (such as an invalid date field).


- Verify the thing does this: Works exactly the way it did before except with additional logic to skip bad Milestone forms.
- Verify the thing does not do that: Change any of its default behavior.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
