### PR TITLE
Add Neuropath version 11 to "Set to zero if blank" rules

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -486,6 +486,13 @@ def set_blanks_to_zero(packet):
     except KeyError:
         pass
 
+    # NP v11 19(r, s, t)
+    try:
+        set_to_zero_if_blank(
+            'NPPDXR', 'NPPDXS', 'NPPDXT')
+    except KeyError:
+        pass
+
 
 def convert(fp, options, out=sys.stdout, err=sys.stderr):
     """

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -588,7 +588,7 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             traceback.print_exc()
             continue
 
-        if not (options.np or options.np10 or options.m or options.lbd or
+        if not (options.np10 or options.m or options.lbd or
                 options.lbdsv or options.ftld or options.csf or options.cv):
             set_blanks_to_zero(packet)
 


### PR DESCRIPTION
This is a small change that's meant to update some fields to "0" if they have been left blank in REDCap. These fields are question 19 parts r, s, t (the three "Other" fields under the "Other Pathologic Diagnoses" section). 

This change was made because every ptid in the brain bank has blank values for these three fields, and it seems the clinicians equate leaving the "Other" fields blank to having no "Other" conditions to specify. This programming will reflect that approach without adding extra work for clinicians to go back and add this information to 200+ ptids.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Export the Neuropath version 11 data from our 1Florida ADRC Brief Data Set REDCap project.
2. From the command-line, run:
$ redcap2nacc -np </path/to/NP11.csv >np_11.txt
3. The output should look like this: regular NACCulator processing with no changes other than three extra "0"s added to each form in the np_11.txt output file.
4. If you pass _some bad value_, the output should look like this: regular NACCulator error reporting with no changes.

- Verify the thing does this: Adds three fields from the Neuropath version 11 form to the "set_blanks_to_zero" function
- Verify the thing does not do that: Change any other processes


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
