### PR TITLE
Remove submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".vscode"]
-	path = .vscode
-	url = https://github.com/ctsit/.vscode


### PR DESCRIPTION
**What does this change do?** 

This change removes the `.vscode` submodule.

**Why was this change made?** 

The submodule was removed because it points to a private repo and nacculator is open source. We shouldn't have CTS-IT specifics as part of a public repo.


## Verification

1. Pull the latest changes and verify that the `.vscode` directory is gone

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [ ] I matched the style of the existing code.
* [ ] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [ ] I used Python's type hinting.
* [ ] I ran the automated tests and ensured they **ALL** passed.
* [ ] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [ ] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [ ] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [ ] I have written the code myself or have given credit where credit is due.
