### PR TITLE
Bump report_handler dependency to 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
 
     install_requires=[
         "PyCap>=2.1.0",
-        "report_handler @ git+https://git@github.com:/ctsit/report_handler.git"
+        "report_handler @ git+https://git@github.com:/ctsit/report_handler.git@1.3.0"
     ],
 
     python_requires=">=3.6.0",


### PR DESCRIPTION
**What does this change do?** 

This change bumps the `report_handler` to 1.3.0.

**Why was this change made?** 

This change was made because the latest release of `report_handler` introduces an import null safety fix.

## Verification

1. Checkout the PR
2. Update the dependencies In the python virtual environment: `pip install --upgrade .`
3. Verify that nacculator can be run without any errors

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [ ] I matched the style of the existing code.
* [ ] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [ ] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [ ] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
