### PR TITLE
Update visit detection to rely on Z1X and presence of A1 for UDS packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ marked "Unverified" or "Complete" for NACCulator to recognize the record, and
 each optional form must be marked as submitted within the Z1X for NACCulator to
 find those forms.
 
+_Note: For UDS visits (the -ivp and -fvp flags), NACCulator also expects the
+A1 subject demographics form to be either Unverified or Complete._
+
 _Note: output is written to `STDOUT`; errors are written to `STDERR`; input is
 expected to be from `STDIN` (the command line) unless a file is specified using
 the `-file` flag._

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -237,7 +237,12 @@ def check_redcap_event(
             form_match_z1 = ''
             record['ivp_z1_complete'] = ''
         form_match_z1x = record['ivp_z1x_complete']
-        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', '']:
+        try:
+            form_match_a1 = record['ivp_a1_complete']
+        except KeyError:
+            form_match_a1 = record['ivp_a1_subject_demographics_complete']
+        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', ''] and \
+           form_match_a1 in ['0', '']:
             return False
     elif options.fvp:
         event_name = 'follow'
@@ -247,7 +252,12 @@ def check_redcap_event(
             form_match_z1 = ''
             record['fvp_z1_complete'] = ''
         form_match_z1x = record['fvp_z1x_complete']
-        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', '']:
+        try:
+            form_match_a1 = record['fvp_a1_complete']
+        except KeyError:
+            form_match_a1 = record['fvp_a1_subject_demographics_complete']
+        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', ''] and \
+           form_match_a1 in ['0', '']:
             return False
     # TODO: add -csf option if/when it is added to the full ADRC project.
     elif options.cv:

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -241,7 +241,7 @@ def check_redcap_event(
             form_match_a1 = record['ivp_a1_complete']
         except KeyError:
             form_match_a1 = record['ivp_a1_subject_demographics_complete']
-        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', ''] and \
+        if (form_match_z1 in ['0', ''] and form_match_z1x in ['0', '']) or \
            form_match_a1 in ['0', '']:
             return False
     elif options.fvp:
@@ -256,7 +256,7 @@ def check_redcap_event(
             form_match_a1 = record['fvp_a1_complete']
         except KeyError:
             form_match_a1 = record['fvp_a1_subject_demographics_complete']
-        if form_match_z1 in ['0', ''] and form_match_z1x in ['0', ''] and \
+        if (form_match_z1 in ['0', ''] and form_match_z1x in ['0', '']) or \
            form_match_a1 in ['0', '']:
             return False
     # TODO: add -csf option if/when it is added to the full ADRC project.

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -35,10 +35,16 @@ class TestRedcapEvent(unittest.TestCase):
         '''
         self.options.ivp = True
         record = {'redcap_event_name': 'initial_visit_year_arm_1',
-                  'ivp_z1_complete': '', 'ivp_z1x_complete': '2', 
-                  'ivp_a1_complete': '2'}
+                  'ivp_z1_complete': '', 'ivp_z1x_complete': '2',
+                  'ivp_a1_complete': '2'}  # condition met to return True
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
+
+        record = {'redcap_event_name': 'initial_visit_year_arm_1',
+                  'ivp_z1_complete': '', 'ivp_z1x_complete': '2',
+                  'ivp_a1_complete': ''}  # condition met to return False
+        result2 = check_redcap_event(self.options, record)
+        self.assertFalse(result2)
 
     def test_for_not_ivp(self):
         '''

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -35,7 +35,8 @@ class TestRedcapEvent(unittest.TestCase):
         '''
         self.options.ivp = True
         record = {'redcap_event_name': 'initial_visit_year_arm_1',
-                  'ivp_z1_complete': '', 'ivp_z1x_complete': '2'}
+                  'ivp_z1_complete': '', 'ivp_z1x_complete': '2', 
+                  'ivp_a1_complete': '2'}
         result = check_redcap_event(self.options, record)
         self.assertTrue(result)
 
@@ -46,7 +47,8 @@ class TestRedcapEvent(unittest.TestCase):
         '''
         self.options.fvp = True
         record = {'redcap_event_name': 'initial_visit_year_arm_1',
-                  'fvp_z1_complete': '', 'fvp_z1x_complete': ''}
+                  'fvp_z1_complete': '', 'fvp_z1x_complete': '',
+                  'fvp_a1_complete': '2'}
         result = check_redcap_event(self.options, record)
         self.assertFalse(result)
 
@@ -68,7 +70,7 @@ class TestRedcapEvent(unittest.TestCase):
         self.options.ivp = True
         record = {'redcap_event_name': 'initial_visit_year_arm_1',
                   'ivp_z1_complete': '', 'ivp_z1x_complete': '',
-                  'lbd_ivp_b1l_complete': '2'}
+                  'lbd_ivp_b1l_complete': '2', 'ivp_a1_complete': '2'}
         incorrect = check_redcap_event(self.options, record)
 
         self.options.lbd = True


### PR DESCRIPTION
This change is an update to address a bug introduced by using the Z1X form in multiple REDCap projects. It changes how NACCulator detects UDS visits when using the -ivp or -fvp flags by requiring that the A1 (Subject Demographics) form is also marked "Unverified" or "Complete". I chose the A1 form because it's required for submission to NACC, and it's necessary to enter the form on the day of the participant's visit so that they show up in our demographics reporting.

This change was made because, when running NACCulator after connecting to multiple projects, NACCulator would print out empty visits when using the -ivp or -fvp flags that caused blank data to overwrite visit data in NACC's working database. It would interpret LBD or FTLD packets with a complete Z1X in the other projects as UDS packets.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the command-line, check out the develop branch of nacculator and run `nacculator_filters nacculator_cfg.ini`
2. Then run `redcap2nacc -ivp <run_06-18-2024/final_Update.csv >run_06-18-2024/ivp_nacc_complete.txt 2>run_06-18-2024/ivp_errors.txt` (or whichever date is your current run date)
3. The output should look like this: Open up ivp_nacc_complete.txt and note the presence of complete PTIDs. However, if you scroll to the bottom of ivp_nacc_complete, you will see duplicated visits with empty data for any participant with FTLD or LBD data in one of the satellite projects.
4. Next, check out this branch and run `redcap2nacc -ivp <run_06-18-2024/final_Update.csv >run_06-18-2024/ivp_nacc_complete.txt 2>run_06-18-2024/ivp_errors.txt` again
5. Open up ivp_nacc_complete.txt and scroll to the bottom and observe that the duplicated visit lines are gone (as are any UDS packets that do not have a complete A1 form).

- Verify the thing does this: Uses the Z1X and A1 forms in combination to identify UDS visit data in the input csv file.
- Verify the thing does not do that: Pass LBD-specific visits through the -ivp or -fvp flags.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
