### PR TITLE
Update FTLD event detection

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -221,12 +221,18 @@ def check_redcap_event(
             return False
     elif options.ftld and options.ivp:
         event_name = 'initial'
-        form_match_ftld = record['ftld_present']
+        try:
+            form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
+        except KeyError:
+            form_match_ftld = record['ftld_ivp_b3f_complete']
         if form_match_ftld in ['0', '']:
             return False
     elif options.ftld and options.fvp:
         event_name = 'follow'
-        form_match_ftld = record['fu_ftld_present']
+        try:
+            form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']
+        except KeyError:
+            form_match_ftld = record['ftld_fvp_b3f_complete']
         if form_match_ftld in ['0', '']:
             return False
     elif options.ivp:


### PR DESCRIPTION
Updates FTLD event detection to depend on B3F presence instead of ftld_present in Z1X to better differentiate from other packets.

This change updates the check_redcap_event function in redcap2nacc for the FTLD ivp and fvp flags. Instead of detecting whether "ftld_present" is checked in the Z1X form, it checks for the B3F form (which is required for FTLD data to submit to NACC) to be marked "Complete" or "Unverified". 

This change was made because of the update to NACCulator's ability to connect to multiple REDCap projects via API. NACCulator's dependence on the Z1X form was causing it to falsely "detect" the FTLD module for any Z1X that had "ftld_present" marked Yes (even those with LBD packet data or UDS packet data), which was printing blank lines in the output txt files and interfering with submission to NACC.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Ensure your nacculator_cfg.ini file connects to UDS, FTLD, and LBD projects.
2. From the command-line, run `nacculator_filters nacculator_cfg.ini`
3. Then, FROM DEVELOP BRANCH, run `redcap2nacc -ftld -ivp <run_current-date/final_Update.csv >run_current-date/fti_nacc_complete.txt 2>run_current-date/fti_errors.txt`
4. Examine the fti_errors.txt file and note how one of the ptids is printing 3 times.
5. Checkout the feature branch and run the command again, and note how in the ftf_errors.txt file the ptid is only being processed once.

- Verify the thing does this: Stops processing false positives for FTLD
- Verify the thing does not do that: Changes anything else about the way NACCulator operates


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
