### PR TITLE
Add a check for valid visit date

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -191,11 +191,11 @@ def check_valid_visit_date(record) -> bool:
     bad_visit_days: bool = False
     todays_date = date.today()
     try:
-        record_date = datetime.strptime(record['visitdate'], '%m-%d-%Y').date()
-    except KeyError:
-        date_list = [record["visitmo"], record["visitday"], record["visityr"]]
+        date_list = [record["visityr"], record["visitmo"], record["visitday"]]
         combined_date = "-".join(date_list)
-        record_date = datetime.strptime(combined_date, '%m-%d-%Y').date()
+        record_date = datetime.strptime(combined_date, '%Y-%m-%d').date()
+    except KeyError:
+        record_date = datetime.strptime(record['visitdate'], '%Y-%m-%d').date()
 
     if record_date > todays_date:
         bad_visit_days = True

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -190,7 +190,12 @@ def check_valid_visit_date(record) -> bool:
     """
     bad_visit_days: bool = False
     todays_date = date.today()
-    record_date = datetime.strptime(record['visitdate'], '%m-%d-%Y').date()
+    try:
+        record_date = datetime.strptime(record['visitdate'], '%m-%d-%Y').date()
+    except KeyError:
+        date_list = [record["visitmo"], record["visitday"], record["visityr"]]
+        combined_date = "-".join(date_list)
+        record_date = datetime.strptime(combined_date, '%m-%d-%Y').date()
 
     if record_date > todays_date:
         bad_visit_days = True

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -12,6 +12,8 @@ import re
 import sys
 import traceback
 import typing
+from datetime import date
+from datetime import datetime
 
 from nacc.uds3 import blanks as blanks_uds3
 from nacc.lbd import blanks as blanks_lbd
@@ -179,6 +181,21 @@ def check_for_bad_characters(field: Field) -> typing.List:
             incompatible.append(percent_char + " (%s)" % num_percent)
 
     return incompatible
+
+
+def check_valid_visit_date(record) -> bool:
+    """
+    Determines whether the record's visit date is in the future, and
+    returns an error if it is past today's date
+    """
+    bad_visit_days: bool = False
+    todays_date = date.today()
+    record_date = datetime.strptime(record['visitdate'], '%m-%d-%Y').date()
+
+    if record_date > todays_date:
+        bad_visit_days = True
+
+    return bad_visit_days
 
 
 def check_redcap_event(
@@ -611,6 +628,23 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
         if options.m or options.tfp or options.tip:
             blanks_uds3.set_zeros_to_blanks(packet)
 
+        # check to make sure the visitdate is in the past
+        date_in_future = check_valid_visit_date(record)
+        if date_in_future:
+            print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                  " visit " + str(record['visitnum']), file=err)
+            print("Record has a visitdate that is past today's date.", file=err)
+            logging.error(
+                '[SKIP] Error for ptid : {}'.format(record['ptid']),
+                extra={
+                    "report_handler": {
+                        "data": {"ptid": record['ptid'], "error": "Record has a visitdate that is past today's date."},
+                        "sheet": "SKIP"
+                    }
+                }
+            )
+            continue
+
         warnings = []
         try:
             warnings += check_blanks(packet, options)
@@ -646,6 +680,11 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             traceback.print_exc()
             continue
 
+        if not options.np and not options.np10 and not options.m and not \
+           options.lbd and not options.lbdsv and not options.ftld and not \
+           options.csf and not options.cv:
+            warnings += check_single_select(packet)
+
         if warnings:
             print("[SKIP] Error for ptid : " + str(record['ptid']) +
                   " visit " + str(record['visitnum']), file=err)
@@ -663,13 +702,7 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             )
             continue
 
-        if not options.np and not options.np10 and not options.m and not \
-           options.lbd and not options.lbdsv and not options.ftld and not \
-           options.csf and not options.cv:
-            warnings += check_single_select(packet)
-
         for form in packet:
-
             try:
                 print(form, file=out)
             except AssertionError as e:

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -190,7 +190,7 @@ def check_valid_visit_date(record, options) -> bool:
     """
     bad_visit_days: bool = False
     todays_date = date.today()
-    if not options.m:
+    if not options.m and not options.np:
         try:
             date_list = [record["visityr"], record["visitmo"], record["visitday"]]
             combined_date = "-".join(date_list)

--- a/tests/test_valid_visitdate.py
+++ b/tests/test_valid_visitdate.py
@@ -4,18 +4,41 @@ from nacc.redcap2nacc import check_valid_visit_date
 from datetime import date
 
 
+class option():
+    flag = 'ivp'
+    iorf = False
+    cv = False
+    csf = False
+    lbd = False
+    tip = False
+    tfp = False
+    tfp3 = False
+    ftld = False
+    ivp = True
+    fvp = False
+    m = False
+    np = False
+
+
 class TestValidVisitdate(unittest.TestCase):
+    '''
+    These tests validate the "check_valid_visit_date" function in redcap2nacc
+    by making sure that the visitdate is not beyond today's date.
+    '''
+
+    def setUp(self):
+        self.options = option()
 
     def test_return_error_if_date_is_past_todays_date(self):
         record = make_filled_form()
         current_year = date.today().year
         record['visityr'] = str(current_year + 1)
-        invalid_date = check_valid_visit_date(record)
+        invalid_date = check_valid_visit_date(record, self.options)
         self.assertTrue(invalid_date)
 
     def test_do_not_return_error_if_date_is_before_todays_date(self):
         record = make_filled_form()
-        valid_date = check_valid_visit_date(record)
+        valid_date = check_valid_visit_date(record, self.options)
         self.assertFalse(valid_date)
 
 

--- a/tests/test_valid_visitdate.py
+++ b/tests/test_valid_visitdate.py
@@ -1,0 +1,36 @@
+import unittest
+
+from nacc.redcap2nacc import check_valid_visit_date
+from datetime import date
+
+
+class TestValidVisitdate(unittest.TestCase):
+
+    def test_return_error_if_date_is_past_todays_date(self):
+        record = make_filled_form()
+        current_year = date.today().year
+        record['visityr'] = str(current_year + 1)
+        invalid_date = check_valid_visit_date(record)
+        self.assertTrue(invalid_date)
+
+    def test_do_not_return_error_if_date_is_before_todays_date(self):
+        record = make_filled_form()
+        valid_date = check_valid_visit_date(record)
+        self.assertFalse(valid_date)
+
+
+def make_filled_form() -> dict:
+    return {
+        # Header
+        'ptid': '1',
+        'adcid': '2',
+        'visitmo': '1',
+        'visitday': '1',
+        'visityr': '2020',
+        'visitnum': '1',
+        'initials': ''
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change adds an additional check to NACCulator's list. The new check is to make sure the packet's visitdate is BEFORE today's date (not in the future) so that it can be submitted to NACC without NACC returning an error for the whole submission file.

I have added corresponding unit tests for the new function.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. Download the testing data from our testing project (udsv3)
2. From the VS Code launch.json, add the args
"args": ["-ivp", "-file", "/path/to/downloaded/test/data.csv"]
and run redcap2nacc in the debugger.
3. The output should look like this: an error that the first ptid has an invalid visit date

- Verify the thing does this: returns a new kind of error when the packet's visitdate is in the future (NACC will only accept packets with visitdates in the past)
- Verify the thing does not do that: anything else


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
