### PR TITLE
Update lbd and ftld z1x detection

### DIFF
--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -12,6 +12,8 @@ import re
 import sys
 import traceback
 import typing
+from datetime import date
+from datetime import datetime
 
 from nacc.uds3 import blanks as blanks_uds3
 from nacc.lbd import blanks as blanks_lbd
@@ -181,6 +183,26 @@ def check_for_bad_characters(field: Field) -> typing.List:
     return incompatible
 
 
+def check_valid_visit_date(record) -> bool:
+    """
+    Determines whether the record's visit date is in the future, and
+    returns an error if it is past today's date
+    """
+    bad_visit_days: bool = False
+    todays_date = date.today()
+    try:
+        date_list = [record["visityr"], record["visitmo"], record["visitday"]]
+        combined_date = "-".join(date_list)
+        record_date = datetime.strptime(combined_date, '%Y-%m-%d').date()
+    except KeyError:
+        record_date = datetime.strptime(record['visitdate'], '%Y-%m-%d').date()
+
+    if record_date > todays_date:
+        bad_visit_days = True
+
+    return bad_visit_days
+
+
 def check_redcap_event(
         options, record, out=sys.stdout, err=sys.stderr) -> bool:
     """
@@ -190,49 +212,67 @@ def check_redcap_event(
     if options.lbd and options.ivp:
         event_name = 'initial'
         try:
-            form_match_lbd = record['lbd_ivp_b1l_complete']
+            form_match_lbd = record['lbd_present']
         except KeyError:
-            form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
+            try:
+                form_match_lbd = record['lbd_ivp_b1l_complete']
+            except KeyError:
+                form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
         if form_match_lbd in ['0', '']:
             return False
     elif options.lbd and options.fvp:
         event_name = 'follow'
         try:
-            form_match_lbd = record['lbd_fvp_b1l_complete']
+            form_match_lbd = record['fu_lbd_present']
         except KeyError:
-            form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
+            try:
+                form_match_lbd = record['lbd_fvp_b1l_complete']
+            except KeyError:
+                form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
         if form_match_lbd in ['0', '']:
             return False
     elif options.lbdsv and options.ivp:
         event_name = 'initial'
-        try:
-            form_match_lbd = record['lbd_ivp_b1l_complete']
+        try: 
+            form_match_lbd = record['lbd_present']
         except KeyError:
-            form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
+            try:
+                form_match_lbd = record['lbd_ivp_b1l_complete']
+            except KeyError:
+                form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
         if form_match_lbd in ['0', '']:
             return False
     elif options.lbdsv and options.fvp:
         event_name = 'follow'
         try:
-            form_match_lbd = record['lbd_fvp_b1l_complete']
+            form_match_lbd = record['fu_lbd_present']
         except KeyError:
-            form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
+            try:
+                form_match_lbd = record['lbd_fvp_b1l_complete']
+            except KeyError:
+                form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
         if form_match_lbd in ['0', '']:
             return False
     elif options.ftld and options.ivp:
         event_name = 'initial'
         try:
-            form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
+            form_match_ftld = record['ftld_present']
         except KeyError:
-            form_match_ftld = record['ftld_ivp_b3f_complete']
+            try:
+                form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
+            except KeyError:
+                form_match_ftld = record['ftld_ivp_b3f_complete']
         if form_match_ftld in ['0', '']:
             return False
     elif options.ftld and options.fvp:
         event_name = 'follow'
         try:
-            form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']
+            form_match_ftld = record['fu_ftld_present']
         except KeyError:
-            form_match_ftld = record['ftld_fvp_b3f_complete']
+            try:
+                form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']
+            except KeyError:
+                form_match_ftld = record['ftld_fvp_b3f_complete']
         if form_match_ftld in ['0', '']:
             return False
     elif options.ivp:
@@ -611,6 +651,23 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
         if options.m or options.tfp or options.tip:
             blanks_uds3.set_zeros_to_blanks(packet)
 
+        # check to make sure the visitdate is in the past
+        date_in_future = check_valid_visit_date(record)
+        if date_in_future:
+            print("[SKIP] Error for ptid : " + str(record['ptid']) +
+                  " visit " + str(record['visitnum']), file=err)
+            print("Record has a visitdate that is past today's date.", file=err)
+            logging.error(
+                '[SKIP] Error for ptid : {}'.format(record['ptid']),
+                extra={
+                    "report_handler": {
+                        "data": {"ptid": record['ptid'], "error": "Record has a visitdate that is past today's date."},
+                        "sheet": "SKIP"
+                    }
+                }
+            )
+            continue
+
         warnings = []
         try:
             warnings += check_blanks(packet, options)
@@ -646,6 +703,11 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             traceback.print_exc()
             continue
 
+        if not options.np and not options.np10 and not options.m and not \
+           options.lbd and not options.lbdsv and not options.ftld and not \
+           options.csf and not options.cv:
+            warnings += check_single_select(packet)
+
         if warnings:
             print("[SKIP] Error for ptid : " + str(record['ptid']) +
                   " visit " + str(record['visitnum']), file=err)
@@ -663,13 +725,7 @@ def convert(fp, options, out=sys.stdout, err=sys.stderr):
             )
             continue
 
-        if not options.np and not options.np10 and not options.m and not \
-           options.lbd and not options.lbdsv and not options.ftld and not \
-           options.csf and not options.cv:
-            warnings += check_single_select(packet)
-
         for form in packet:
-
             try:
                 print(form, file=out)
             except AssertionError as e:


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

This change adds extra "try" statements to catch Z1X status for LBD, LBD short version, and FTLD modules.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

This change was made because the code used to only check if LBD data was present by checking if data was in the form rather than verifying that the module is present on the Z1X. Our center entered LBD data and then wanted to remove it from NACC and marked the module "absent" on the Z1X, but the packet is still being submitted. This change should fix that issue.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From the command-line, run 
redcap2nacc -fvp -ftld </path/to/lbd/data.csv >path/to/output.txt
3. The output should look like this: LBD data should be absent for PTIDs that have data in the LBD project but the Z1X marks their LBD module as "absent".
4. If you pass _some bad value_, the output should look like this: normal NACCulator error messages

- Verify the thing does this: Checks the Z1X to see if LBD data is present, rather than the LBD forms themselves
- Verify the thing does not do that: Any other changes


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
