### PR TITLE
Add a skip for optional modules (LBD, LBD Short Version, FTLD) that are associated with a UDSv4 visit year

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ Both LBD / LBDSV and FTLD forms can have IVP or FVP arguments.
     $ redcap2nacc -f cleanPtid -meta nacculator_cfg.ini <data.csv >filtered_data.csv
 
 
+HOW TO Skip UDSv4 Packets in the LBD and FTLD Modules
+-----------------------------------------------------
+
+With the release of UDSv4, the LBD, LBD Short Version, and FTLD modules can be
+associated with either a UDSv3 or a UDSv4 visit. This is because the modules
+themselves have not been changed between the UDS versions. UDSv3-associated
+LBD, LBDSV, or FTLD module packets can be submitted to NACC's legacy submission
+system via NACCulator as usual, but the UDSv4-associated visits must be
+submitted to the new Flywheel system. In order to skip these UDSv4-associated
+visits with NACCulator, the center needs to add a field to their LBD, LBDSV,
+and/or FTLD REDCap projects in the Header form.
+
+This field should be labeled "udsv3_or_udsv4" and have two options:
+- 3, UDSv3
+- 4, UDSv4
+
+NACCulator will skip any packet that has a value of 4 in this field. These
+packets should go to Flywheel instead.
+
+
 HOW TO Filter Data Using NACCulator
 -----------------------------------
 

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -216,6 +216,7 @@ def check_redcap_event(
     # whole packet as missing on the Z1X)
     if options.lbd and options.ivp:
         event_name = 'initial'
+        form_match_lbd = '0'
         try:
             if record['lbd_present'] == '1':
                 try:
@@ -237,6 +238,7 @@ def check_redcap_event(
             return False
     elif options.lbd and options.fvp:
         event_name = 'follow'
+        form_match_lbd = '0'
         try:
             if record['fu_lbd_present'] == '1':
                 try:
@@ -256,6 +258,7 @@ def check_redcap_event(
             return False
     elif options.lbdsv and options.ivp:
         event_name = 'initial'
+        form_match_lbd = '0'
         try:
             if record['lbd_present'] == '1':
                 try:
@@ -275,6 +278,7 @@ def check_redcap_event(
             return False
     elif options.lbdsv and options.fvp:
         event_name = 'follow'
+        form_match_lbd = '0'
         try:
             if record['fu_lbd_present'] == '1':
                 try:
@@ -294,6 +298,7 @@ def check_redcap_event(
             return False
     elif options.ftld and options.ivp:
         event_name = 'initial'
+        form_match_ftld = '0'
         try:
             if record['ftld_present'] == '1':
                 try:
@@ -313,6 +318,7 @@ def check_redcap_event(
             return False
     elif options.ftld and options.fvp:
         event_name = 'follow'
+        form_match_ftld = '0'
         try:
             if record['fu_ftld_present'] == '1':
                 try:

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -217,7 +217,7 @@ def check_redcap_event(
     if options.lbd and options.ivp:
         event_name = 'initial'
         try:
-            if record['lbd_present'] == 1:
+            if record['lbd_present'] == '1':
                 try:
                     form_match_lbd = record['lbd_ivp_b1l_complete']
                 except KeyError:
@@ -227,12 +227,18 @@ def check_redcap_event(
                 form_match_lbd = record['lbd_ivp_b1l_complete']
             except KeyError:
                 form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
-        if form_match_lbd in ['0', '']:
+        # Check whether the packet is associated with a UDSv3 or UDSv4 visit
+        # (UDSv4 visits should not go to the legacy submission portal)
+        try:
+            uds_version = record['udsv3_or_udsv4']
+        except KeyError:
+            uds_version = '3'
+        if form_match_lbd in ['0', ''] or uds_version == '4':
             return False
     elif options.lbd and options.fvp:
         event_name = 'follow'
         try:
-            if record['fu_lbd_present'] == 1:
+            if record['fu_lbd_present'] == '1':
                 try:
                     form_match_lbd = record['lbd_fvp_b1l_complete']
                 except KeyError:
@@ -242,12 +248,16 @@ def check_redcap_event(
                 form_match_lbd = record['lbd_fvp_b1l_complete']
             except KeyError:
                 form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
-        if form_match_lbd in ['0', '']:
+        try:
+            uds_version = record['udsv3_or_udsv4']
+        except KeyError:
+            uds_version = '3'
+        if form_match_lbd in ['0', ''] or uds_version == '4':
             return False
     elif options.lbdsv and options.ivp:
         event_name = 'initial'
         try:
-            if record['lbd_present'] == 1:
+            if record['lbd_present'] == '1':
                 try:
                     form_match_lbd = record['lbd_ivp_b1l_complete']
                 except KeyError:
@@ -257,12 +267,16 @@ def check_redcap_event(
                 form_match_lbd = record['lbd_ivp_b1l_complete']
             except KeyError:
                 form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
-        if form_match_lbd in ['0', '']:
+        try:
+            uds_version = record['udsv3_or_udsv4']
+        except KeyError:
+            uds_version = '3'
+        if form_match_lbd in ['0', ''] or uds_version == '4':
             return False
     elif options.lbdsv and options.fvp:
         event_name = 'follow'
         try:
-            if record['fu_lbd_present'] == 1:
+            if record['fu_lbd_present'] == '1':
                 try:
                     form_match_lbd = record['lbd_fvp_b1l_complete']
                 except KeyError:
@@ -272,12 +286,16 @@ def check_redcap_event(
                 form_match_lbd = record['lbd_fvp_b1l_complete']
             except KeyError:
                 form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
-        if form_match_lbd in ['0', '']:
+        try:
+            uds_version = record['udsv3_or_udsv4']
+        except KeyError:
+            uds_version = '3'
+        if form_match_lbd in ['0', ''] or uds_version == '4':
             return False
     elif options.ftld and options.ivp:
         event_name = 'initial'
         try:
-            if record['ftld_present'] == 1:
+            if record['ftld_present'] == '1':
                 try:
                     form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
                 except KeyError:
@@ -287,12 +305,16 @@ def check_redcap_event(
                 form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
             except KeyError:
                 form_match_ftld = record['ftld_ivp_b3f_complete']
-        if form_match_ftld in ['0', '']:
+        try:
+            uds_version = record['udsv3_or_udsv4']
+        except KeyError:
+            uds_version = '3'
+        if form_match_ftld in ['0', ''] or uds_version == '4':
             return False
     elif options.ftld and options.fvp:
         event_name = 'follow'
         try:
-            if record['fu_ftld_present'] == 1:
+            if record['fu_ftld_present'] == '1':
                 try:
                     form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']
                 except KeyError:
@@ -302,7 +324,11 @@ def check_redcap_event(
                 form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']
             except KeyError:
                 form_match_ftld = record['ftld_fvp_b3f_complete']
-        if form_match_ftld in ['0', '']:
+        try:
+            uds_version = record['udsv3_or_udsv4']
+        except KeyError:
+            uds_version = '3'
+        if form_match_ftld in ['0', ''] or uds_version == '4':
             return False
     elif options.ivp:
         event_name = 'initial'

--- a/nacc/redcap2nacc.py
+++ b/nacc/redcap2nacc.py
@@ -210,10 +210,18 @@ def check_redcap_event(
     Determines if the record's redcap_event_name and filled forms match the
     options flag
     """
+    # for LBD, LBD Short Version, and FTLD modules, check if the Z1X has the
+    # corresponding switch before just checking for presence of data
+    # (sometimes sites will collect incomplete data for a visit and mark the
+    # whole packet as missing on the Z1X)
     if options.lbd and options.ivp:
         event_name = 'initial'
         try:
-            form_match_lbd = record['lbd_present']
+            if record['lbd_present'] == 1:
+                try:
+                    form_match_lbd = record['lbd_ivp_b1l_complete']
+                except KeyError:
+                    form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
         except KeyError:
             try:
                 form_match_lbd = record['lbd_ivp_b1l_complete']
@@ -224,7 +232,11 @@ def check_redcap_event(
     elif options.lbd and options.fvp:
         event_name = 'follow'
         try:
-            form_match_lbd = record['fu_lbd_present']
+            if record['fu_lbd_present'] == 1:
+                try:
+                    form_match_lbd = record['lbd_fvp_b1l_complete']
+                except KeyError:
+                    form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
         except KeyError:
             try:
                 form_match_lbd = record['lbd_fvp_b1l_complete']
@@ -234,8 +246,12 @@ def check_redcap_event(
             return False
     elif options.lbdsv and options.ivp:
         event_name = 'initial'
-        try: 
-            form_match_lbd = record['lbd_present']
+        try:
+            if record['lbd_present'] == 1:
+                try:
+                    form_match_lbd = record['lbd_ivp_b1l_complete']
+                except KeyError:
+                    form_match_lbd = record['lbd_ivp_b1l_clinical_symptoms_and_exam_complete']
         except KeyError:
             try:
                 form_match_lbd = record['lbd_ivp_b1l_complete']
@@ -246,7 +262,11 @@ def check_redcap_event(
     elif options.lbdsv and options.fvp:
         event_name = 'follow'
         try:
-            form_match_lbd = record['fu_lbd_present']
+            if record['fu_lbd_present'] == 1:
+                try:
+                    form_match_lbd = record['lbd_fvp_b1l_complete']
+                except KeyError:
+                    form_match_lbd = record['lbd_fvp_b1l_clinical_symptoms_and_exam_complete']
         except KeyError:
             try:
                 form_match_lbd = record['lbd_fvp_b1l_complete']
@@ -257,7 +277,11 @@ def check_redcap_event(
     elif options.ftld and options.ivp:
         event_name = 'initial'
         try:
-            form_match_ftld = record['ftld_present']
+            if record['ftld_present'] == 1:
+                try:
+                    form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
+                except KeyError:
+                    form_match_ftld = record['ftld_ivp_b3f_complete']
         except KeyError:
             try:
                 form_match_ftld = record['ftld_ivp_b3f_supplemental_updrs_complete']
@@ -268,7 +292,11 @@ def check_redcap_event(
     elif options.ftld and options.fvp:
         event_name = 'follow'
         try:
-            form_match_ftld = record['fu_ftld_present']
+            if record['fu_ftld_present'] == 1:
+                try:
+                    form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']
+                except KeyError:
+                    form_match_ftld = record['ftld_fvp_b3f_complete']
         except KeyError:
             try:
                 form_match_ftld = record['ftld_fvp_b3f_supplemental_updrs_complete']

--- a/tests/test_check_redcap_event.py
+++ b/tests/test_check_redcap_event.py
@@ -95,6 +95,23 @@ class TestRedcapEvent(unittest.TestCase):
         result = check_redcap_event(self.options, record)
         self.assertNotEqual('NP', result)
 
+    def test_for_udsv4_in_optional_module(self):
+        '''
+        Checks that the packet is skipped when udsv3_or_udsv4 in an optional
+        module project's Header form is equal to '4' for visits that are
+        associated with a UDSv4 visit; UDSv4-associated LBD and FTLD packets
+        should go to the new Flywheel interface and not to the legacy
+        submission system.
+        '''
+        self.options.lbdsv = True
+        self.options.ivp = True
+        record = {'redcap_event_name': 'initial_visit_year_arm_1',
+                  'lbd_present': '1',
+                  'lbd_ivp_b1l_complete': '2',
+                  'udsv3_or_udsv4': '4'}  # condition met to return False
+        result = check_redcap_event(self.options, record)
+        self.assertFalse(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces one change and one bug fix. 

The bug was that duplicate lines were being printed in the .txt output files when running nacculator with the -lbdsv, -lbd, or -ftld flags due to only checking the Z1X for presence of optional module data (which, for our project, is synced with the main UDS3 project). This means that the (blank) main project data was also being processed with these flags, resulting in doubled PTIDs with blank data in every form. I have updated the REDCap event detection code to check for the Z1X switch AND B1L data present in the module before processing begins.

The new addition to the code is to check whether the optional module packet is associated with a UDSv3 or UDSv4 visit before processing begins. This is because UDSv4-associated LBD packets, for example, should go to the new Flywheel portal instead of the UDSv3 legacy submission system. This requires that you add a field to your LBD and/or FTLD REDCap project called "udsv3_or_udsv4" with the options "3, UDSv3" and "4, UDSv4" so that NACCulator can check the version number.

If you don't have this field, REDCap will assume that the version is UDSv3 and continue processing as normal.

This change was made to address the fact that the LBD and FTLD modules / projects were not updated with the rollout of UDSv4, meaning that the modules can be collected during a UDSv3 OR a UDSv4 visit with no differentiation between the two. UDSv4 packet data cannot be submitted to the NACC legacy portal, which is where NACCulator's output is designed to go, so we need a method of skipping these UDSv4-associated packets.

I have also added a unit test to test_check_redcap_event.py associated with the udsv3_or_udsv4 field.


## Verification

_List the steps needed to make sure this thing works. Be precise._

1. From REDCap, export our LBD Short Version data (or test data, though I think we might not have a dedicated testing project for LBD)
2. From the command-line, run:
`redcap2nacc -lbdsv -fvp <path/to/REDCap_export.csv >lbd_test.txt 2>lbd_test_error.txt`
3. The output should look like this: Currently no LBD packets should be skipped, as they have not been marked "associated with a UDSv4 visit". There should only be one packet per PTID and visit number in the output file (if you compare with develop branch you might see two or even three duplicates).
4. If you pass _data with errors_, the output should look like this: the regular NACCulator error output; I haven't changed anything except the event detection logic.

- Verify the thing does this: No longer prints duplicates
- Verify the thing does not do that: Does not currently skip any PTIDs due to the UDSv4 association (there are no LBD UDSv4 visits currently)


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
